### PR TITLE
ASH-TEST02

### DIFF
--- a/src/main/java/com/peoplein/moiming/controller/MoimMemberController.java
+++ b/src/main/java/com/peoplein/moiming/controller/MoimMemberController.java
@@ -2,6 +2,7 @@ package com.peoplein.moiming.controller;
 
 import com.peoplein.moiming.NetworkSetting;
 import com.peoplein.moiming.domain.Member;
+import com.peoplein.moiming.domain.MemberMoimLinker;
 import com.peoplein.moiming.model.ResponseModel;
 import com.peoplein.moiming.model.dto.domain.MoimMemberInfoDto;
 import com.peoplein.moiming.model.dto.domain.MyMoimLinkerDto;
@@ -39,8 +40,9 @@ public class MoimMemberController {
     @PostMapping("/requestJoin")
     public ResponseModel<MyMoimLinkerDto> requestJoin(@RequestBody MoimJoinRequestDto moimJoinRequestDto) {
         Member curMember = (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        MyMoimLinkerDto responseData = moimMemberService.requestJoin(moimJoinRequestDto, curMember);
-        return ResponseModel.createResponse(responseData);
+        MemberMoimLinker memberMoimLinker = moimMemberService.requestJoin(moimJoinRequestDto, curMember);
+        MyMoimLinkerDto myMoimLinkerDto = new MyMoimLinkerDto(memberMoimLinker);
+        return ResponseModel.createResponse(myMoimLinkerDto);
     }
 
     /*

--- a/src/main/java/com/peoplein/moiming/controller/MoimMemberController.java
+++ b/src/main/java/com/peoplein/moiming/controller/MoimMemberController.java
@@ -51,7 +51,8 @@ public class MoimMemberController {
     @PatchMapping("/decideJoin")
     public ResponseModel<MoimMemberInfoDto> decideJoin(@RequestBody MoimMemberActionRequestDto moimMemberActionRequestDto) {
         Member curMember = (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        MoimMemberInfoDto moimMemberInfoDto = moimMemberService.decideJoin(moimMemberActionRequestDto, curMember);
+        MemberMoimLinker memberMoimLinker = moimMemberService.decideJoin(moimMemberActionRequestDto);
+        MoimMemberInfoDto moimMemberInfoDto = new MoimMemberInfoDto(memberMoimLinker);
         return ResponseModel.createResponse(moimMemberInfoDto);
     }
 

--- a/src/main/java/com/peoplein/moiming/domain/MemberMoimLinker.java
+++ b/src/main/java/com/peoplein/moiming/domain/MemberMoimLinker.java
@@ -1,7 +1,9 @@
 package com.peoplein.moiming.domain;
 
 import com.peoplein.moiming.domain.enums.MoimMemberState;
+import com.peoplein.moiming.domain.enums.MoimMemberStateAction;
 import com.peoplein.moiming.domain.enums.MoimRoleType;
+import com.peoplein.moiming.model.dto.domain.MoimMemberInfoDto;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -112,5 +114,17 @@ public class MemberMoimLinker extends BaseEntity {
 
     public boolean canRejoin() {
         return banRejoin;
+    }
+
+    public void judgeJoin(MoimMemberStateAction stateAction) {
+        if (stateAction.equals(MoimMemberStateAction.PERMIT)) {
+            this.memberState = MoimMemberState.ACTIVE;
+        } else if (stateAction.equals(MoimMemberStateAction.DECLINE)) {
+            // TODO :: 이 멤버에게 [해당 모임에서 까였다고] 알림을 보내야 한다 (MEMBERINFO 를 JOIN 한 이유)
+            this.memberState = MoimMemberState.DECLINE;
+        } else { // 여기 들어오면 안되는 에러 요청
+            // TODO :: ERROR
+            throw new IllegalArgumentException("unexpected State");
+        }
     }
 }

--- a/src/main/java/com/peoplein/moiming/domain/MemberMoimLinker.java
+++ b/src/main/java/com/peoplein/moiming/domain/MemberMoimLinker.java
@@ -66,7 +66,10 @@ public class MemberMoimLinker extends BaseEntity {
          */
         this.moim = moim;
         this.moim.getMemberMoimLinkers().add(this);
-        this.moim.addCurMemberCount();
+
+        if (memberState.equals(MoimMemberState.ACTIVE)) {
+            this.moim.addCurMemberCount();
+        }
     }
 
     public boolean shouldPersist() {
@@ -122,7 +125,7 @@ public class MemberMoimLinker extends BaseEntity {
 
     public void judgeJoin(MoimMemberStateAction stateAction) {
         if (stateAction.equals(MoimMemberStateAction.PERMIT)) {
-            this.memberState = MoimMemberState.ACTIVE;
+            doActiveMemberState();
         } else if (stateAction.equals(MoimMemberStateAction.DECLINE)) {
             // TODO :: 이 멤버에게 [해당 모임에서 까였다고] 알림을 보내야 한다 (MEMBERINFO 를 JOIN 한 이유)
             this.memberState = MoimMemberState.DECLINE;
@@ -130,5 +133,15 @@ public class MemberMoimLinker extends BaseEntity {
             // TODO :: ERROR
             throw new IllegalArgumentException("unexpected State");
         }
+    }
+
+    private void doActiveMemberState() {
+        this.moim.addCurMemberCount();
+        this.memberState = MoimMemberState.ACTIVE;
+    }
+
+    private void doInactiveMemberState(MoimMemberState moimMemberState) {
+        this.moim.minusCurMemberCount();
+        this.memberState = moimMemberState;
     }
 }

--- a/src/main/java/com/peoplein/moiming/domain/MemberMoimLinker.java
+++ b/src/main/java/com/peoplein/moiming/domain/MemberMoimLinker.java
@@ -41,6 +41,7 @@ public class MemberMoimLinker extends BaseEntity {
     private String inactiveReason;
     private boolean banRejoin;
 
+    // 생성자
 
     public static MemberMoimLinker memberJoinMoim(Member member, Moim moim, MoimRoleType moimRoleType, MoimMemberState memberState) {
         MemberMoimLinker memberMoimLinker = new MemberMoimLinker(member, moim, moimRoleType, memberState);
@@ -68,31 +69,10 @@ public class MemberMoimLinker extends BaseEntity {
         this.moim.addCurMemberCount();
     }
 
-    public static MemberMoimLinker processRequestJoin(Member curMember, Moim moim, MoimMemberState memberState, Optional<MemberMoimLinker> previousMemberMoimLinker) {
-        if (moim.shouldCreateNewMemberMoimLinker(previousMemberMoimLinker)) {
-            // 신규 가입하는 경우
-            return MemberMoimLinker.memberJoinMoim(curMember, moim, MoimRoleType.NORMAL, memberState);
-        } else {
-            // 탈퇴 후 재가입 하는 경우
-            MemberMoimLinker memberMoimLinker = previousMemberMoimLinker.get();
-            memberMoimLinker.upDateRoleTypeAndState(MoimRoleType.NORMAL, memberState);
-            return memberMoimLinker;
-        }
-    }
-
     public boolean shouldPersist() {
         return Objects.isNull(this.id);
     }
 
-    public void changeMemberState(MoimMemberState memberState) {
-        if(!memberState.equals(MoimMemberState.ACTIVE)) {
-            this.moim.minusCurMemberCount();
-        }else{ // 기존에 INACTIVE 상태 쪽이던 회원이 다시 ACTIVE 하게 됨
-            this.moim.addCurMemberCount();
-        }
-        // 이미 있던 모임 상태이므로
-        this.memberState = memberState;
-    }
 
     public void setMoimRoleType(MoimRoleType moimRoleType) {
         this.moimRoleType = moimRoleType;
@@ -115,6 +95,30 @@ public class MemberMoimLinker extends BaseEntity {
     public boolean canRejoin() {
         return banRejoin;
     }
+
+    // 비즈니스 로직
+    public static MemberMoimLinker processRequestJoin(Member curMember, Moim moim, MoimMemberState memberState, Optional<MemberMoimLinker> previousMemberMoimLinker) {
+        if (moim.shouldCreateNewMemberMoimLinker(previousMemberMoimLinker)) {
+            // 신규 가입하는 경우
+            return MemberMoimLinker.memberJoinMoim(curMember, moim, MoimRoleType.NORMAL, memberState);
+        } else {
+            // 탈퇴 후 재가입 하는 경우
+            MemberMoimLinker memberMoimLinker = previousMemberMoimLinker.get();
+            memberMoimLinker.upDateRoleTypeAndState(MoimRoleType.NORMAL, memberState);
+            return memberMoimLinker;
+        }
+    }
+
+    public void changeMemberState(MoimMemberState memberState) {
+        if(!memberState.equals(MoimMemberState.ACTIVE)) {
+            this.moim.minusCurMemberCount();
+        }else{ // 기존에 INACTIVE 상태 쪽이던 회원이 다시 ACTIVE 하게 됨
+            this.moim.addCurMemberCount();
+        }
+        // 이미 있던 모임 상태이므로
+        this.memberState = memberState;
+    }
+
 
     public void judgeJoin(MoimMemberStateAction stateAction) {
         if (stateAction.equals(MoimMemberStateAction.PERMIT)) {

--- a/src/main/java/com/peoplein/moiming/domain/MemberMoimLinker.java
+++ b/src/main/java/com/peoplein/moiming/domain/MemberMoimLinker.java
@@ -15,7 +15,7 @@ import java.util.Optional;
 @Table(name = "member_moim_linker")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MemberMoimLinker {
+public class MemberMoimLinker extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,8 +39,6 @@ public class MemberMoimLinker {
     private String inactiveReason;
     private boolean banRejoin;
 
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
 
     public static MemberMoimLinker memberJoinMoim(Member member, Moim moim, MoimRoleType moimRoleType, MoimMemberState memberState) {
         MemberMoimLinker memberMoimLinker = new MemberMoimLinker(member, moim, moimRoleType, memberState);
@@ -58,7 +56,6 @@ public class MemberMoimLinker {
         /*
          초기화
          */
-        this.createdAt = LocalDateTime.now();
         this.banRejoin = false;
 
         /*
@@ -99,9 +96,6 @@ public class MemberMoimLinker {
         this.moimRoleType = moimRoleType;
     }
 
-    public void setUpdatedAt(LocalDateTime updatedAt) {
-        this.updatedAt = updatedAt;
-    }
 
     public void setInactiveReason(String inactiveReason) {
         this.inactiveReason = inactiveReason;

--- a/src/main/java/com/peoplein/moiming/domain/enums/MoimMemberState.java
+++ b/src/main/java/com/peoplein/moiming/domain/enums/MoimMemberState.java
@@ -16,5 +16,6 @@ public enum MoimMemberState {
     WAIT_BY_BAN,
 
     DORMANT,
-    NOTFOUND // 탈퇴
+    NOTFOUND, // 탈퇴
+    DECLINE
 }

--- a/src/main/java/com/peoplein/moiming/model/dto/domain/MoimMemberInfoDto.java
+++ b/src/main/java/com/peoplein/moiming/model/dto/domain/MoimMemberInfoDto.java
@@ -47,6 +47,27 @@ public class MoimMemberInfoDto {
         this.memberPfImg = memberPfImg;
     }
 
+    public MoimMemberInfoDto(MemberMoimLinker memberMoimLinker) {
+        this.memberId = memberMoimLinker.getMember().getId();
+        this.memberUid = memberMoimLinker.getMember().getUid();
+        this.memberName = memberMoimLinker.getMember().getMemberInfo().getMemberName();
+        this.memberEmail = memberMoimLinker.getMember().getMemberInfo().getMemberEmail();
+        this.memberGender = memberMoimLinker.getMember().getMemberInfo().getMemberGender();
+        this.memberPfImg = memberMoimLinker.getMember().getMemberInfo().getMemberPfImg();
+        this.moimRoleType = memberMoimLinker.getMoimRoleType();
+        this.moimMemberState = memberMoimLinker.getMemberState();
+        this.createdAt = memberMoimLinker.getCreatedAt();
+
+        if (updatedAt == null) {
+            // 강퇴당한 경우 updateAt 생성되지 않음.
+            this.updatedAt = LocalDateTime.now();
+        } else {
+            this.updatedAt = memberMoimLinker.getUpdatedAt();
+        }
+
+    }
+
+
     /*
      MemberMoimLinker 정보 세팅을 위한 setter open
      */

--- a/src/main/java/com/peoplein/moiming/service/MoimMemberService.java
+++ b/src/main/java/com/peoplein/moiming/service/MoimMemberService.java
@@ -67,7 +67,7 @@ public class MoimMemberService {
      *  - null : 재가입 불가능하게 강퇴당한 경우
      *  - MyMoimLinkerDto : 재가입이 아닌 경우.
      */
-    public MyMoimLinkerDto requestJoin(MoimJoinRequestDto moimJoinRequestDto, Member curMember) {
+    public MemberMoimLinker requestJoin(MoimJoinRequestDto moimJoinRequestDto, Member curMember) {
 
         // default
         MoimMemberState memberState = MoimMemberState.ACTIVE;
@@ -100,13 +100,7 @@ public class MoimMemberService {
             memberMoimLinkerRepository.save(memberMoimLinker);
         }
 
-        // TODO : createAt, updateAt은 @Transactional이 완료되는 경우에 생성됨. 해결하려면 MemberMoimLinker를 return 한 후, Controller에서 랩핑해야 할 듯.
-        return new MyMoimLinkerDto(
-                memberMoimLinker.getMoimRoleType(),
-                memberMoimLinker.getMemberState(),
-                memberMoimLinker.getCreatedAt(),
-                memberMoimLinker.getUpdatedAt()
-        );
+        return memberMoimLinker;
     }
 
 

--- a/src/main/java/com/peoplein/moiming/service/MoimMemberService.java
+++ b/src/main/java/com/peoplein/moiming/service/MoimMemberService.java
@@ -80,19 +80,15 @@ public class MoimMemberService {
         // 재가입 요청
         if (previousMemberMoimLinker.isPresent()) {
             MemberMoimLinker previousLinker = previousMemberMoimLinker.get();
-
             if (previousLinker.canRejoin()) {
                 memberState = MoimMemberState.WAIT_BY_BAN;
             } else {
                 return null; // 재가입 불가능할 경우, null값 반환.
             }
-
         }else{
-
             if (moim.isHasRuleJoin()) { // 가입조건 판별한다
                 memberState = moim.checkRuleJoinCondition(curMember.getMemberInfo(), memberMoimLinkers);
             }
-
         }
 
         MemberMoimLinker memberMoimLinker = MemberMoimLinker.processRequestJoin(curMember, moim, memberState, previousMemberMoimLinker);

--- a/src/main/java/com/peoplein/moiming/service/MoimMemberService.java
+++ b/src/main/java/com/peoplein/moiming/service/MoimMemberService.java
@@ -116,7 +116,7 @@ public class MoimMemberService {
         if (moimMemberActionRequestDto.getStateAction().equals(MoimMemberStateAction.PERMIT)) {
 
             memberMoimLinker.changeMemberState(MoimMemberState.ACTIVE);
-            memberMoimLinker.setUpdatedAt(LocalDateTime.now());
+//            memberMoimLinker.setUpdatedAt(LocalDateTime.now());
 
             moimMemberInfoDto = new MoimMemberInfoDto(
                     memberMoimLinker.getMember().getId(), memberMoimLinker.getMember().getUid()
@@ -148,7 +148,7 @@ public class MoimMemberService {
             // 요청한 유저의 MemberMoimLinker
 
             memberMoimLinker.changeMemberState(MoimMemberState.IBW);
-            memberMoimLinker.setUpdatedAt(LocalDateTime.now());
+//            memberMoimLinker.setUpdatedAt(LocalDateTime.now());
 
             // TODO : MoimRoleType 이 Normal 일 겨우만 수월하게 진행?
 
@@ -175,7 +175,7 @@ public class MoimMemberService {
                 memberMoimLinker.changeMemberState(MoimMemberState.IBF);
             }
 
-            memberMoimLinker.setUpdatedAt(LocalDateTime.now());
+//            memberMoimLinker.setUpdatedAt(LocalDateTime.now());
 
         } else { // 여기 들어오면 안되는 에러 요청
             // TODO :: ERROR
@@ -201,7 +201,7 @@ public class MoimMemberService {
 
         // 모임의 역할 변경된다
         memberMoimLinker.setMoimRoleType(moimMemberActionRequestDto.getRoleAction());
-        memberMoimLinker.setUpdatedAt(LocalDateTime.now());
+//        memberMoimLinker.setUpdatedAt(LocalDateTime.now());
 
         // 그 Member 의 MoimMemberInfo 를 전달
         return MoimMemberInfoDto.createMemberInfoDto(memberMoimLinker);

--- a/src/main/java/com/peoplein/moiming/service/MoimMemberService.java
+++ b/src/main/java/com/peoplein/moiming/service/MoimMemberService.java
@@ -107,35 +107,10 @@ public class MoimMemberService {
     /*
      WAIT 상태인 유저의 요청을 처리한다
      */
-    public MoimMemberInfoDto decideJoin(MoimMemberActionRequestDto moimMemberActionRequestDto, Member curMember) {
-
-        // 영속화
+    public MemberMoimLinker decideJoin(MoimMemberActionRequestDto moimMemberActionRequestDto) {
         MemberMoimLinker memberMoimLinker = memberMoimLinkerRepository.findWithMemberInfoByMemberAndMoimId(moimMemberActionRequestDto.getMemberId(), moimMemberActionRequestDto.getMoimId());
-        MoimMemberInfoDto moimMemberInfoDto = null;
-
-        if (moimMemberActionRequestDto.getStateAction().equals(MoimMemberStateAction.PERMIT)) {
-
-            memberMoimLinker.changeMemberState(MoimMemberState.ACTIVE);
-//            memberMoimLinker.setUpdatedAt(LocalDateTime.now());
-
-            moimMemberInfoDto = new MoimMemberInfoDto(
-                    memberMoimLinker.getMember().getId(), memberMoimLinker.getMember().getUid()
-                    , memberMoimLinker.getMember().getMemberInfo().getMemberName(), memberMoimLinker.getMember().getMemberInfo().getMemberEmail()
-                    , memberMoimLinker.getMember().getMemberInfo().getMemberGender(), memberMoimLinker.getMember().getMemberInfo().getMemberPfImg()
-                    , memberMoimLinker.getMoimRoleType(), memberMoimLinker.getMemberState()
-                    , memberMoimLinker.getCreatedAt(), memberMoimLinker.getUpdatedAt()
-            );
-
-        } else if (moimMemberActionRequestDto.getStateAction().equals(MoimMemberStateAction.DECLINE)) {
-
-            // TODO :: 이 멤버에게 [해당 모임에서 까였다고] 알림을 보내야 한다 (MEMBERINFO 를 JOIN 한 이유)
-            memberMoimLinkerRepository.remove(memberMoimLinker);
-
-        } else { // 여기 들어오면 안되는 에러 요청
-            // TODO :: ERROR
-        }
-
-        return moimMemberInfoDto;
+        memberMoimLinker.judgeJoin(moimMemberActionRequestDto.getStateAction());
+        return memberMoimLinker;
     }
 
     public MoimMemberInfoDto exitMoim(MoimMemberActionRequestDto moimMemberActionRequestDto, Member curMember) {

--- a/src/test/java/com/peoplein/moiming/TestUtils.java
+++ b/src/test/java/com/peoplein/moiming/TestUtils.java
@@ -8,6 +8,7 @@ import com.peoplein.moiming.domain.fixed.Role;
 import com.peoplein.moiming.domain.rules.RuleJoin;
 import com.peoplein.moiming.model.dto.domain.MoimDto;
 import com.peoplein.moiming.model.dto.domain.RuleJoinDto;
+import com.peoplein.moiming.model.dto.request.MoimMemberActionRequestDto;
 import com.peoplein.moiming.model.dto.request.MoimPostRequestDto;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -179,4 +180,10 @@ public class TestUtils {
                 postTitle, postContent, isNotice, MoimPostCategory.EXTRA);
         return moimPostRequestDto;
     }
+
+    public static MoimMemberActionRequestDto createActionRequestDto(Long moimId, Long memberId, MoimMemberStateAction moimMemberStateAction) {
+        return new MoimMemberActionRequestDto(
+                moimId, memberId, moimMemberStateAction, MoimRoleType.NORMAL, "", true);
+    }
+
 }

--- a/src/test/java/com/peoplein/moiming/TestUtils.java
+++ b/src/test/java/com/peoplein/moiming/TestUtils.java
@@ -138,6 +138,10 @@ public class TestUtils {
         return MemberMoimLinker.memberJoinMoim(member, moim, MoimRoleType.NORMAL, MoimMemberState.ACTIVE);
     }
 
+    public static MemberMoimLinker createNormalMemberMoimLinkerWithWait(Member member, Moim moim) {
+        return MemberMoimLinker.memberJoinMoim(member, moim, MoimRoleType.NORMAL, MoimMemberState.WAIT_BY_MOIM_CNT);
+    }
+
 
     public static List<CategoryName> initCategoryName() {
         return List.of(CategoryName.ALCOHOL);

--- a/src/test/java/com/peoplein/moiming/domain/MemberMoimLinkerTest.java
+++ b/src/test/java/com/peoplein/moiming/domain/MemberMoimLinkerTest.java
@@ -16,7 +16,7 @@ class MemberMoimLinkerTest {
         // given
         Member member = TestUtils.initMemberAndMemberInfo();
         Moim moim = TestUtils.initMoimAndRuleJoin();
-        MemberMoimLinker memberMoimLinker = TestUtils.createNormalMemberMoimLinker(member, moim);
+        MemberMoimLinker memberMoimLinker = TestUtils.createNormalMemberMoimLinkerWithWait(member, moim);
         MoimMemberStateAction input = MoimMemberStateAction.PERMIT;
 
         // when
@@ -24,6 +24,7 @@ class MemberMoimLinkerTest {
 
         // then
         assertThat(memberMoimLinker.getMemberState()).isEqualTo(MoimMemberState.ACTIVE);
+        assertThat(memberMoimLinker.getMoim().getCurMemberCount()).isEqualTo(1);
     }
 
     @Test
@@ -31,7 +32,7 @@ class MemberMoimLinkerTest {
         // given
         Member member = TestUtils.initMemberAndMemberInfo();
         Moim moim = TestUtils.initMoimAndRuleJoin();
-        MemberMoimLinker memberMoimLinker = TestUtils.createNormalMemberMoimLinker(member, moim);
+        MemberMoimLinker memberMoimLinker = TestUtils.createNormalMemberMoimLinkerWithWait(member, moim);
         MoimMemberStateAction input = MoimMemberStateAction.DECLINE;
 
         // when
@@ -39,6 +40,7 @@ class MemberMoimLinkerTest {
 
         // then
         assertThat(memberMoimLinker.getMemberState()).isEqualTo(MoimMemberState.DECLINE);
+        assertThat(memberMoimLinker.getMoim().getCurMemberCount()).isEqualTo(0);
     }
 
     @Test

--- a/src/test/java/com/peoplein/moiming/domain/MemberMoimLinkerTest.java
+++ b/src/test/java/com/peoplein/moiming/domain/MemberMoimLinkerTest.java
@@ -1,0 +1,56 @@
+package com.peoplein.moiming.domain;
+
+import com.peoplein.moiming.TestUtils;
+import com.peoplein.moiming.domain.enums.MoimMemberState;
+import com.peoplein.moiming.domain.enums.MoimMemberStateAction;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MemberMoimLinkerTest {
+
+    @Test
+    void judgeJoinSuccess() {
+        // given
+        Member member = TestUtils.initMemberAndMemberInfo();
+        Moim moim = TestUtils.initMoimAndRuleJoin();
+        MemberMoimLinker memberMoimLinker = TestUtils.createNormalMemberMoimLinker(member, moim);
+        MoimMemberStateAction input = MoimMemberStateAction.PERMIT;
+
+        // when
+        memberMoimLinker.judgeJoin(input);
+
+        // then
+        assertThat(memberMoimLinker.getMemberState()).isEqualTo(MoimMemberState.ACTIVE);
+    }
+
+    @Test
+    void judgeJoinDecline() {
+        // given
+        Member member = TestUtils.initMemberAndMemberInfo();
+        Moim moim = TestUtils.initMoimAndRuleJoin();
+        MemberMoimLinker memberMoimLinker = TestUtils.createNormalMemberMoimLinker(member, moim);
+        MoimMemberStateAction input = MoimMemberStateAction.DECLINE;
+
+        // when
+        memberMoimLinker.judgeJoin(input);
+
+        // then
+        assertThat(memberMoimLinker.getMemberState()).isEqualTo(MoimMemberState.DECLINE);
+    }
+
+    @Test
+    void judgeJoinThrowErrorWithUnexpectedInput() {
+        // given
+        Member member = TestUtils.initMemberAndMemberInfo();
+        Moim moim = TestUtils.initMoimAndRuleJoin();
+        MemberMoimLinker memberMoimLinker = TestUtils.createNormalMemberMoimLinker(member, moim);
+        MoimMemberStateAction input = MoimMemberStateAction.IBF;
+
+        // when + then
+        assertThatThrownBy(() -> memberMoimLinker.judgeJoin(input))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/peoplein/moiming/service/MoimMemberIntegrationServiceTest.java
+++ b/src/test/java/com/peoplein/moiming/service/MoimMemberIntegrationServiceTest.java
@@ -63,11 +63,11 @@ public class MoimMemberIntegrationServiceTest {
         MoimJoinRequestDto requestDto = new MoimJoinRequestDto(moim.getId());
 
         // when
-        MyMoimLinkerDto myMoimLinkerDto = moimMemberService.requestJoin(requestDto, member);
+        MemberMoimLinker memberMoimLinker = moimMemberService.requestJoin(requestDto, member);
 
         // then
-        assertThat(myMoimLinkerDto.getMoimRoleType()).isEqualTo(MoimRoleType.NORMAL);
-        assertThat(myMoimLinkerDto.getMemberState()).isEqualTo(MoimMemberState.ACTIVE);
+        assertThat(memberMoimLinker.getMoimRoleType()).isEqualTo(MoimRoleType.NORMAL);
+        assertThat(memberMoimLinker.getMemberState()).isEqualTo(MoimMemberState.ACTIVE);
     }
 
     @Test
@@ -86,11 +86,11 @@ public class MoimMemberIntegrationServiceTest {
         MoimJoinRequestDto requestDto = new MoimJoinRequestDto(moim.getId());
 
         // when
-        MyMoimLinkerDto myMoimLinkerDto = moimMemberService.requestJoin(requestDto, member);
+        MemberMoimLinker memberMoimLinker = moimMemberService.requestJoin(requestDto, member);
 
         // then
-        assertThat(myMoimLinkerDto.getMoimRoleType()).isEqualTo(MoimRoleType.NORMAL);
-        assertThat(myMoimLinkerDto.getMemberState()).isEqualTo(MoimMemberState.ACTIVE);
+        assertThat(memberMoimLinker.getMoimRoleType()).isEqualTo(MoimRoleType.NORMAL);
+        assertThat(memberMoimLinker.getMemberState()).isEqualTo(MoimMemberState.ACTIVE);
     }
 
     @Test
@@ -111,12 +111,12 @@ public class MoimMemberIntegrationServiceTest {
         MoimJoinRequestDto requestDto = new MoimJoinRequestDto(moim.getId());
 
         // when
-        MyMoimLinkerDto myMoimLinkerDto = moimMemberService.requestJoin(requestDto, member);
+        MemberMoimLinker result = moimMemberService.requestJoin(requestDto, member);
 
         // then
         List<MemberMoimLinker> findMoimLinker = memberMoimLinkerRepository.findByMemberId(member.getId());
 
-        assertThat(myMoimLinkerDto.getMemberState()).isEqualTo(MoimMemberState.WAIT_BY_BAN);
+        assertThat(result.getMemberState()).isEqualTo(MoimMemberState.WAIT_BY_BAN);
         assertThat(findMoimLinker.size()).isEqualTo(1);
     }
 
@@ -138,10 +138,10 @@ public class MoimMemberIntegrationServiceTest {
         MoimJoinRequestDto requestDto = new MoimJoinRequestDto(moim.getId());
 
         // when
-        MyMoimLinkerDto myMoimLinkerDto = moimMemberService.requestJoin(requestDto, member);
+        MemberMoimLinker result = moimMemberService.requestJoin(requestDto, member);
 
         // then
-        assertThat(myMoimLinkerDto).isNull();
+        assertThat(result).isNull();
     }
 
     void flushAndClearEM() {

--- a/src/test/java/com/peoplein/moiming/service/MoimMemberIntegrationServiceTest.java
+++ b/src/test/java/com/peoplein/moiming/service/MoimMemberIntegrationServiceTest.java
@@ -91,8 +91,11 @@ public class MoimMemberIntegrationServiceTest {
         MemberMoimLinker memberMoimLinker = moimMemberService.requestJoin(requestDto, member);
 
         // then
+        Moim findMoim = moimRepository.findById(moim.getId());
+
         assertThat(memberMoimLinker.getMoimRoleType()).isEqualTo(MoimRoleType.NORMAL);
         assertThat(memberMoimLinker.getMemberState()).isEqualTo(MoimMemberState.ACTIVE);
+        assertThat(findMoim.getCurMemberCount()).isEqualTo(1);
     }
 
     @Test
@@ -117,9 +120,11 @@ public class MoimMemberIntegrationServiceTest {
 
         // then
         List<MemberMoimLinker> findMoimLinker = memberMoimLinkerRepository.findByMemberId(member.getId());
+        Moim findMoim = moimRepository.findById(moim.getId());
 
         assertThat(result.getMemberState()).isEqualTo(MoimMemberState.WAIT_BY_BAN);
         assertThat(findMoimLinker.size()).isEqualTo(1);
+        assertThat(findMoim.getCurMemberCount()).isEqualTo(0);
     }
 
     @Test
@@ -143,7 +148,10 @@ public class MoimMemberIntegrationServiceTest {
         MemberMoimLinker result = moimMemberService.requestJoin(requestDto, member);
 
         // then
+        Moim findMoim = moimRepository.findById(moim.getId());
+
         assertThat(result).isNull();
+        assertThat(findMoim.getCurMemberCount()).isEqualTo(0);
     }
 
     @Test
@@ -167,6 +175,7 @@ public class MoimMemberIntegrationServiceTest {
 
         // then
         assertThat(result.getMemberState()).isEqualTo(MoimMemberState.ACTIVE);
+        assertThat(result.getMoim().getCurMemberCount()).isEqualTo(1);
     }
 
 


### PR DESCRIPTION
### [requestJoin의 반환 타입을 MemberMoimLinker로 변경 --> 재사용 위해서]
- Service 계층에서 Dto를 반환하면, 컨트롤러 메서드 - 서비스 메서드가 1:1로 매칭되게 되는 것 같습니다. Service 계층은 비즈니스 로직인데, Dto를 반환하기 보다는 Entity를 반환해서 컨트롤러에서 Dto로 한번 랩핑하는 것이 맞는 것 같습니다. DTO는 언제든지 바뀔 수 있는 녀석이니까요.
- 가급적이면 Input으로 들어오는 데이터도 Dto가 아니라 필요한 값들만 들어오면 좋을 것 같습니다. 

### [MemberMoimLinker에 BaseEntity 추가]
- UpdateAt, CreatedAt 적용될 수 있도록 BaseEntity 추가했습니다. 


### [decideJoin 메서드 코너케이스 대응 및 로직 수정 + 테스트 코드 작성]
- decideJoin에서 이전에는 가입 거절 당한 유저의 MemberMoimLinker를 DB에서 삭제하도록 되어있었습니다. 그런데 그럴 경우 banRejoin 등의 모든 이력이 다 사라지기 때문에 문제였습니다. 이 부분을 MemberMoimState.DECLIEN 필드를 추가해서 DB에 저장하도록 해두었습니다. 

### [ACTIVE 일 때만 MoimCount 올라가도록 수정 및 테스트코드 수정]
- 생성자에서 MemberMoimLinker를 생성할 때마다 Moim Count가 올라가도록 되어있었습니다. ACTIVE인 경우에만 올라가도록 수정했고, 관련해서 테스트 코드도 약간 수정했습니다. 