### PR TITLE
테스트 컨테이너, AuthService Refactoring, MoimPostService Refactoring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,14 +55,19 @@ dependencies {
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 
 	// Test 환경
-	runtimeOnly 'com.h2database:h2'
+//	runtimeOnly 'com.h2database:h2'
 
 
 	// https://mvnrepository.com/artifact/org.mockito/mockito-core
 	testImplementation 'org.mockito:mockito-core:4.10.0'
 	testImplementation 'org.mockito:mockito-junit-jupiter:4.10.0'
 
+	// https://mvnrepository.com/artifact/org.testcontainers/junit-jupiter
+	testImplementation 'org.testcontainers:junit-jupiter:1.17.6'
+	testImplementation 'org.testcontainers:mysql:1.17.6'
 
+	testRuntimeOnly 'com.mysql:mysql-connector-j'
+//	untimeOnly 'com.mysql:mysql-connector-j'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/peoplein/moiming/InitDatabaseQuery.java
+++ b/src/main/java/com/peoplein/moiming/InitDatabaseQuery.java
@@ -10,10 +10,7 @@ import com.peoplein.moiming.domain.fixed.Role;
 import com.peoplein.moiming.domain.rules.MoimRule;
 import com.peoplein.moiming.domain.rules.RuleJoin;
 import com.peoplein.moiming.domain.rules.RulePersist;
-import com.peoplein.moiming.repository.CategoryRepository;
-import com.peoplein.moiming.repository.MemberRepository;
-import com.peoplein.moiming.repository.MoimRepository;
-import com.peoplein.moiming.repository.MoimReviewRepository;
+import com.peoplein.moiming.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -30,7 +27,6 @@ import java.util.List;
 
 
 @Component
-@RequiredArgsConstructor
 public class InitDatabaseQuery {
 
     private final EntityManager em;
@@ -39,7 +35,23 @@ public class InitDatabaseQuery {
     private final MemberRepository memberRepository;
     private final MoimRepository moimRepository;
     private final MoimReviewRepository moimReviewRepository;
+    private final RoleRepository roleRepository;
 
+    public InitDatabaseQuery(EntityManager em,
+                             PasswordEncoder passwordEncoder,
+                             CategoryRepository categoryRepository,
+                             MemberRepository memberRepository,
+                             MoimRepository moimRepository,
+                             MoimReviewRepository moimReviewRepository,
+                             RoleRepository roleRepository) {
+        this.em = em;
+        this.passwordEncoder = passwordEncoder;
+        this.categoryRepository = categoryRepository;
+        this.memberRepository = memberRepository;
+        this.moimRepository = moimRepository;
+        this.moimReviewRepository = moimReviewRepository;
+        this.roleRepository = roleRepository;
+    }
 
     private Long moim1Id;
     private Long moimPostId;
@@ -53,72 +65,50 @@ public class InitDatabaseQuery {
     }
 
     public void initMemberWithAdminGrant() {
-        MemberInfo mi = new MemberInfo(
-                InitConstant.WOOSEOK_EMAIL,
-                InitConstant.WOOSEOK_NAME,
-                InitConstant.WOOSEOK_GENDER
-        );
+
+        Role role = roleRepository.findByRoleType(RoleType.ADMIN);
 
         Member member = Member.createMember(
                 InitConstant.WOOSEOK_UID,
                 passwordEncoder.encode(InitConstant.WOOSEOK_PASS),
-                mi
-        );
+                InitConstant.WOOSEOK_EMAIL,
+                InitConstant.WOOSEOK_NAME,
+                InitConstant.WOOSEOK_GENDER,
+                role);
 
-        Role role = em.createQuery("select r from Role r where r.roleType = :roleType", Role.class)
-                .setParameter("roleType", RoleType.ADMIN)
-                .getSingleResult();
-
-        MemberRoleLinker.grantRoleToMember(member, role);
         em.persist(member);
     }
 
     public void initMemberWithUserGrant() {
-        MemberInfo mi = new MemberInfo(
-                InitConstant.WOOJIN_EMAIL,
-                InitConstant.WOOJIN_NAME,
-                InitConstant.WOOJIN_GENDER
-        );
 
-        MemberInfo mi2 = new MemberInfo(
-                InitConstant.BYUNGHO_EMAIL,
-                InitConstant.BYUNGHO_NAME,
-                InitConstant.BYUNGHO_GENDER
-        );
+        Role role = roleRepository.findByRoleType(RoleType.USER);
 
-        MemberInfo mi3 = new MemberInfo(
-                InitConstant.JUBIN_EMAIL,
-                InitConstant.JUBIN_NAME,
-                InitConstant.JUBIN_GENDER
-        );
-
-        Member member = Member.createMember(
+        Member member1 = Member.createMember(
                 InitConstant.WOOJIN_UID,
                 passwordEncoder.encode(InitConstant.WOOJIN_PASS),
-                mi
-        );
+                InitConstant.WOOJIN_EMAIL,
+                InitConstant.WOOJIN_NAME,
+                InitConstant.WOOJIN_GENDER,
+                role);
 
         Member member2 = Member.createMember(
                 InitConstant.BYUNGHO_UID,
                 passwordEncoder.encode(InitConstant.BYUNGHO_PASS),
-                mi2
-        );
+                InitConstant.BYUNGHO_EMAIL,
+                InitConstant.BYUNGHO_NAME,
+                InitConstant.BYUNGHO_GENDER,
+                role);
 
         Member member3 = Member.createMember(
                 InitConstant.JUBIN_UID,
                 passwordEncoder.encode(InitConstant.JUBIN_PASS),
-                mi3
-        );
+                InitConstant.JUBIN_EMAIL,
+                InitConstant.JUBIN_NAME,
+                InitConstant.JUBIN_GENDER,
+                role);
 
-        Role role = em.createQuery("select r from Role r where r.roleType = :roleType", Role.class)
-                .setParameter("roleType", RoleType.USER)
-                .getSingleResult();
 
-        MemberRoleLinker.grantRoleToMember(member, role);
-        MemberRoleLinker.grantRoleToMember(member2, role);
-        MemberRoleLinker.grantRoleToMember(member3, role);
-
-        em.persist(member);
+        em.persist(member1);
         em.persist(member2);
         em.persist(member3);
 

--- a/src/main/java/com/peoplein/moiming/domain/Member.java
+++ b/src/main/java/com/peoplein/moiming/domain/Member.java
@@ -4,6 +4,8 @@ package com.peoplein.moiming.domain;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.peoplein.moiming.domain.enums.MemberGender;
+import com.peoplein.moiming.domain.fixed.Role;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -75,8 +77,22 @@ public class Member extends BaseEntity{
 
     }
 
-    public static Member createMember(String uid, String password, MemberInfo memberInfo) {
-        return new Member(uid, password, memberInfo);
+//    public static Member createMember(String uid, String password, MemberInfo memberInfo) {
+//        return new Member(uid, password, memberInfo);
+//    }
+
+    // Password should be always encrypted.
+    public static Member createMember(String uid,
+                                      String encryptedPassword,
+                                      String email,
+                                      String memberName,
+                                      MemberGender memberGender,
+                                      Role role
+                                      ) {
+        MemberInfo memberInfo = new MemberInfo(email, memberName, memberGender);
+        Member createdMember = new Member(uid, encryptedPassword, memberInfo);
+        MemberRoleLinker.grantRoleToMember(createdMember, role);
+        return createdMember;
     }
 
 

--- a/src/main/java/com/peoplein/moiming/domain/MemberMoimLinker.java
+++ b/src/main/java/com/peoplein/moiming/domain/MemberMoimLinker.java
@@ -24,11 +24,11 @@ public class MemberMoimLinker extends BaseEntity {
     @Column(name = "member_moim_linker_id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "moim_id")
     private Moim moim;
 

--- a/src/main/java/com/peoplein/moiming/domain/MoimPost.java
+++ b/src/main/java/com/peoplein/moiming/domain/MoimPost.java
@@ -15,7 +15,7 @@ import java.util.List;
 @Getter
 @Table(name = "moim_post")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MoimPost {
+public class MoimPost extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE)
@@ -28,8 +28,6 @@ public class MoimPost {
     private boolean isNotice;
     private boolean hasFiles;
 
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
     private String updatedUid;
 
     /*
@@ -68,8 +66,6 @@ public class MoimPost {
         this.moim = moim;
         this.member = member;
 
-        // 초기화
-        this.createdAt = LocalDateTime.now();
     }
 
     public void addPostComment(PostComment postComment) {
@@ -102,9 +98,6 @@ public class MoimPost {
         this.isNotice = notice;
     }
 
-    public void setUpdatedAt(LocalDateTime updatedAt) {
-        this.updatedAt = updatedAt;
-    }
 
     public void setUpdatedUid(String updatedUid) {
         this.updatedUid = updatedUid;

--- a/src/main/java/com/peoplein/moiming/model/dto/domain/MemberDto.java
+++ b/src/main/java/com/peoplein/moiming/model/dto/domain/MemberDto.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.peoplein.moiming.domain.Member;
 import com.peoplein.moiming.domain.MemberRoleLinker;
 import lombok.*;
 
@@ -32,6 +33,16 @@ public class MemberDto {
         this.roles = memberRoleLinkers.stream()
                 .map(MemberRoleDto::new)
                 .collect(Collectors.toList());
+    }
+
+    public static MemberDto createMemberDtoWhenSignIn(Member signInMember) {
+        MemberDto memberDto = MemberDto.builder().id(signInMember.getId())
+                .uid(signInMember.getUid())
+                .createdAt(signInMember.getCreatedAt())
+                .build();
+
+        memberDto.convertLinkerToDto(signInMember.getRoles());
+        return memberDto;
     }
 
 }

--- a/src/main/java/com/peoplein/moiming/model/dto/domain/MemberInfoDto.java
+++ b/src/main/java/com/peoplein/moiming/model/dto/domain/MemberInfoDto.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.peoplein.moiming.domain.MemberInfo;
 import com.peoplein.moiming.domain.enums.MemberGender;
 import lombok.*;
 
@@ -26,6 +27,17 @@ public class MemberInfoDto {
 //    private String memberBankNumber;
 
     private LocalDateTime createdAt;
+
 //    private LocalDateTime updatedAt;
+
+
+    public static MemberInfoDto createMemberInfoDtoWhenSignIn(MemberInfo memberInfo) {
+        return MemberInfoDto.builder().memberName(memberInfo.getMemberName())
+                .memberEmail(memberInfo.getMemberEmail())
+                .memberGender(memberInfo.getMemberGender())
+                .createdAt(memberInfo.getCreatedAt())
+                .build();
+    }
+
 
 }

--- a/src/main/java/com/peoplein/moiming/model/dto/domain/MoimPostDto.java
+++ b/src/main/java/com/peoplein/moiming/model/dto/domain/MoimPostDto.java
@@ -59,6 +59,22 @@ public class MoimPostDto {
 
     }
 
+    public static MoimPostDto createMoimPostDto(MoimPost moimPost,boolean isCreatorCurMember) {
+        return new MoimPostDto(moimPost.getId()
+                , moimPost.getPostTitle()
+                , moimPost.getPostContent()
+                , moimPost.getMoimPostCategory()
+                , moimPost.isNotice()
+                , moimPost.getCreatedAt()
+                , moimPost.getUpdatedAt()
+                , moimPost.getUpdatedUid()
+                , moimPost.isHasFiles()
+                , isCreatorCurMember
+                , null
+        );
+    }
+
+
     /*
      Constructor -2
      MoimPost Entity 전달을 통한 Dto 형성

--- a/src/main/java/com/peoplein/moiming/repository/MoimPostRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/MoimPostRepository.java
@@ -25,4 +25,6 @@ public interface MoimPostRepository {
 
     void remove(MoimPost moimPost);
 
+    void removeMoimPostExecute(MoimPost moimPost);
+
 }

--- a/src/main/java/com/peoplein/moiming/repository/MoimPostRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/MoimPostRepository.java
@@ -12,6 +12,8 @@ public interface MoimPostRepository {
 
     MoimPost findWithMemberById(Long moimPostId);
 
+    MoimPost findWithMemberId(Long moimPostId, Long memberId);
+
     MoimPost findWithMoimAndMemberById(Long moimPostId);
     MoimPost findWithMoimAndMemberInfoById(Long moimPostId);
 

--- a/src/main/java/com/peoplein/moiming/repository/PostCommentRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/PostCommentRepository.java
@@ -14,6 +14,8 @@ public interface PostCommentRepository {
 
     PostComment findWithMoimPostAndMoimById(Long postCommentId);
 
+    List<PostComment> findWithMoimPostId(Long moimPostId);
+
     void remove(PostComment postComment);
 
     Long removeAllByMoimPostId(Long moimPostId);

--- a/src/main/java/com/peoplein/moiming/repository/PostFileRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/PostFileRepository.java
@@ -1,0 +1,6 @@
+package com.peoplein.moiming.repository;
+
+public interface PostFileRepository {
+
+    void removeWithMoimPostId(Long moimId);
+}

--- a/src/main/java/com/peoplein/moiming/repository/jpa/MoimPostJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/MoimPostJpaRepository.java
@@ -51,6 +51,14 @@ public class MoimPostJpaRepository implements MoimPostRepository {
     }
 
     @Override
+    public MoimPost findWithMemberId(Long moimPostId, Long memberId) {
+        return queryFactory
+                .selectFrom(moimPost)
+                .where(moimPost.id.eq(moimPostId).and(moimPost.member.id.eq(memberId)))
+                .fetchOne();
+    }
+
+    @Override
     public MoimPost findWithMoimAndMemberById(Long moimPostId) {
         /*
          JPQL Query : select mp from MoimPost mp

--- a/src/main/java/com/peoplein/moiming/repository/jpa/MoimPostJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/MoimPostJpaRepository.java
@@ -2,6 +2,7 @@ package com.peoplein.moiming.repository.jpa;
 
 import com.peoplein.moiming.domain.MoimPost;
 import com.peoplein.moiming.repository.MoimPostRepository;
+import com.peoplein.moiming.repository.PostFileRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -22,6 +23,7 @@ public class MoimPostJpaRepository implements MoimPostRepository {
     private final EntityManager em;
 
     private final JPAQueryFactory queryFactory;
+    private final PostFileRepository postFileRepository;
 
     @Override
     public Long save(MoimPost moimPost) {
@@ -125,6 +127,13 @@ public class MoimPostJpaRepository implements MoimPostRepository {
     @Override
     public void remove(MoimPost moimPost) {
         em.remove(moimPost);
+    }
+
+
+    @Override
+    public void removeMoimPostExecute(MoimPost moimPost) {
+        postFileRepository.removeWithMoimPostId(moimPost.getId());
+        remove(moimPost);
     }
 
 }

--- a/src/main/java/com/peoplein/moiming/repository/jpa/PostCommentJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/PostCommentJpaRepository.java
@@ -52,6 +52,14 @@ public class PostCommentJpaRepository implements PostCommentRepository {
     }
 
     @Override
+    public List<PostComment> findWithMoimPostId(Long moimPostId) {
+        return queryFactory
+                .selectFrom(postComment)
+                .where(postComment.moimPost.id.eq(moimPostId))
+                .fetch();
+    }
+
+    @Override
     public void remove(PostComment postComment) {
         em.remove(postComment);
     }

--- a/src/main/java/com/peoplein/moiming/repository/jpa/PostFileJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/PostFileJpaRepository.java
@@ -1,0 +1,35 @@
+package com.peoplein.moiming.repository.jpa;
+
+import com.peoplein.moiming.domain.QPostFile;
+import com.peoplein.moiming.repository.PostFileRepository;
+import com.querydsl.jpa.impl.JPADeleteClause;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+
+import static com.peoplein.moiming.domain.QPostComment.postComment;
+import static com.peoplein.moiming.domain.QPostFile.*;
+
+@Repository
+public class PostFileJpaRepository implements PostFileRepository {
+
+    private final EntityManager em;
+    private final JPAQueryFactory queryFactory;
+    private final PostFileSpringJpaRepository jpaRepository;
+
+    public PostFileJpaRepository(EntityManager em, JPAQueryFactory queryFactory, PostFileSpringJpaRepository jpaRepository) {
+        this.em = em;
+        this.queryFactory = queryFactory;
+        this.jpaRepository = jpaRepository;
+    }
+
+
+    @Override
+    public void removeWithMoimPostId(Long moimPostId) {
+        queryFactory
+                .delete(postFile)
+                .where(postFile.moimPost.id.eq(moimPostId))
+                .execute();
+    }
+}

--- a/src/main/java/com/peoplein/moiming/repository/jpa/PostFileSpringJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/PostFileSpringJpaRepository.java
@@ -1,0 +1,10 @@
+package com.peoplein.moiming.repository.jpa;
+
+import com.peoplein.moiming.domain.PostFile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface PostFileSpringJpaRepository extends JpaRepository<PostFile, Long> {
+
+//    void removeByMoimPostId(Long moimPostId);
+}

--- a/src/main/java/com/peoplein/moiming/repository/jpa/RoleJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/RoleJpaRepository.java
@@ -1,29 +1,38 @@
 package com.peoplein.moiming.repository.jpa;
 
+import com.peoplein.moiming.domain.fixed.QRole;
 import com.peoplein.moiming.domain.fixed.Role;
 import com.peoplein.moiming.domain.enums.RoleType;
 import com.peoplein.moiming.repository.RoleRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
 
+import static com.peoplein.moiming.domain.fixed.QRole.role;
+
 @Repository
 @RequiredArgsConstructor
 public class RoleJpaRepository implements RoleRepository {
 
+    private final JPAQueryFactory queryFactory;
     private final EntityManager em;
 
     @Override
     public Role findById(Long id) {
-        return em.find(Role.class, id);
+        return queryFactory
+                .selectFrom(role)
+                .where(role.id.eq(id))
+                .fetchOne();
     }
 
     @Override
     public Role findByRoleType(RoleType roleType) {
-        return em.createQuery("select r from Role r where r.roleType = :roleType", Role.class)
-                .setParameter("roleType", roleType)
-                .getSingleResult();
+        return queryFactory
+                .selectFrom(role)
+                .where(role.roleType.eq(roleType))
+                .fetchOne();
     }
 
     @Override

--- a/src/main/java/com/peoplein/moiming/security/service/SecurityMemberService.java
+++ b/src/main/java/com/peoplein/moiming/security/service/SecurityMemberService.java
@@ -7,6 +7,7 @@ import com.peoplein.moiming.repository.MemberRepository;
 import com.peoplein.moiming.security.domain.SecurityMember;
 import com.peoplein.moiming.security.provider.token.MoimingTokenProvider;
 import com.peoplein.moiming.security.provider.token.MoimingTokenType;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.GrantedAuthority;

--- a/src/main/java/com/peoplein/moiming/service/MoimPostService.java
+++ b/src/main/java/com/peoplein/moiming/service/MoimPostService.java
@@ -198,7 +198,7 @@ public class MoimPostService {
 
         if (isAnyUpdated) {
 
-            moimPost.setUpdatedAt(LocalDateTime.now());
+//            moimPost.setUpdatedAt(LocalDateTime.now());
             moimPost.setUpdatedUid(curMember.getUid());
 
             return new MoimPostDto(moimPost.getId()

--- a/src/main/java/com/peoplein/moiming/service/MoimPostService.java
+++ b/src/main/java/com/peoplein/moiming/service/MoimPostService.java
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Service;
 import javax.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 
@@ -158,62 +159,26 @@ public class MoimPostService {
 
     public MoimPostDto updatePost(MoimPostRequestDto moimPostRequestDto, Member curMember) {
 
-        // MoimPost 조회
-        MoimPost moimPost = moimPostRepository.findWithMemberById(moimPostRequestDto.getMoimPostId());
-
-        // 요청 유저의 권한 체킹, NULL 체킹
-        if (Objects.isNull(moimPost)) {
-            log.error("요청한 게시물을 찾을 수 없는 경우");
-            throw new RuntimeException("요청한 게시물을 찾을 수 없는 경우");
-        }
+        MoimPost moimPost = moimPostRepository.findWithMemberId(moimPostRequestDto.getMoimPostId(),
+                curMember.getId());
 
         // TODO :: 수정할 권한 - 작성자인지 확인
-        if (moimPost.getMember().getId().equals(curMember.getId())) {
-            log.error("게시물을 수정할 권한이 없는 경우 :: 작성자가 아님");
-            throw new RuntimeException("게시물을 수정할 권한이 없는 경우 :: 작성자가 아님");
+        if (Objects.isNull(moimPost)) {
+            throw new IllegalArgumentException("요청할 게시물이 없거나, 작성자가 아닙니다.");
         }
 
-        boolean isAnyUpdated = false;
+        boolean updated = moimPost.update(
+                moimPostRequestDto.getPostTitle(),
+                moimPostRequestDto.getPostContent(),
+                moimPostRequestDto.isNotice(),
+                moimPostRequestDto.getMoimPostCategory(),
+                curMember.getUid());
 
-        // 현재 Post 와 들어온 요청의 차이점 확인, Update 진행
-        if (!moimPostRequestDto.getPostTitle().equals(moimPost.getPostTitle())) {
-            isAnyUpdated = true;
-            moimPost.changePostTitle(moimPostRequestDto.getPostTitle());
-        }
-
-        if (!moimPostRequestDto.getPostContent().equals(moimPost.getPostContent())) {
-            isAnyUpdated = true;
-            moimPost.changePostContent(moimPostRequestDto.getPostContent());
-        }
-
-        if (moimPostRequestDto.isNotice() != moimPost.isNotice()) {
-            isAnyUpdated = true;
-            moimPost.setNotice(moimPost.isNotice());
-        }
-
-        if (moimPostRequestDto.getMoimPostCategory().equals(moimPost.getMoimPostCategory())) {
-            isAnyUpdated = true;
-            moimPost.changePostCategory(moimPostRequestDto.getMoimPostCategory());
-        }
-
-        if (isAnyUpdated) {
-
-//            moimPost.setUpdatedAt(LocalDateTime.now());
-            moimPost.setUpdatedUid(curMember.getUid());
-
-            return new MoimPostDto(moimPost.getId()
-                    , moimPost.getPostTitle()
-                    , moimPost.getPostContent()
-                    , moimPost.getMoimPostCategory()
-                    , moimPost.isNotice()
-                    , moimPost.getCreatedAt()
-                    , moimPost.getUpdatedAt()
-                    , moimPost.getUpdatedUid()
-                    , moimPost.isHasFiles()
-                    , true // 수정자는 생성자
-                    , null
-            );
+        if (updated) {
+            return MoimPostDto.createMoimPostDto(moimPost, true);
         } else {
+            // TODO : 수정 사항이 없는 것은 에러일까? 이 부분 논의 필요.
+            // TODO : 로그가 필요한 지도 확인 필요.
             // 수정요청이 들어왔으나 수정된 사항이 없음
             log.error("수정된 사항이 없는 경우");
             throw new RuntimeException("수정된 사항이 없는 경우");

--- a/src/test/java/com/peoplein/moiming/BaseTest.java
+++ b/src/test/java/com/peoplein/moiming/BaseTest.java
@@ -1,0 +1,46 @@
+package com.peoplein.moiming;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+
+import javax.sql.DataSource;
+
+@SpringBootTest
+public class BaseTest {
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+
+    public static GenericContainer container;
+    @BeforeAll
+    public static void setUp() {
+
+        container = new MySQLContainer("mysql:8.0.31")
+                .withDatabaseName("test")
+                .withUsername("testuser")
+                .withPassword("testpass")
+                .withExposedPorts(3306);
+
+        container.start();
+
+        Integer mappedPort = container.getFirstMappedPort();
+        System.setProperty("MYSQL_PORT", mappedPort.toString());
+    }
+
+    @BeforeEach
+    void truncateTable() {
+        TestUtils.truncateAllTable(jdbcTemplate);
+    }
+
+}

--- a/src/test/java/com/peoplein/moiming/MoimingApplicationTests.java
+++ b/src/test/java/com/peoplein/moiming/MoimingApplicationTests.java
@@ -1,10 +1,11 @@
 package com.peoplein.moiming;
 
+import com.peoplein.moiming.domain.BaseEntity;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class MoimingApplicationTests {
+class MoimingApplicationTests extends BaseTest {
 
 	@Test
 	void contextLoads() {

--- a/src/test/java/com/peoplein/moiming/TestUtils.java
+++ b/src/test/java/com/peoplein/moiming/TestUtils.java
@@ -10,6 +10,7 @@ import com.peoplein.moiming.model.dto.domain.MoimDto;
 import com.peoplein.moiming.model.dto.domain.RuleJoinDto;
 import com.peoplein.moiming.model.dto.request.MoimMemberActionRequestDto;
 import com.peoplein.moiming.model.dto.request.MoimPostRequestDto;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -188,6 +189,36 @@ public class TestUtils {
     public static MoimMemberActionRequestDto createActionRequestDto(Long moimId, Long memberId, MoimMemberStateAction moimMemberStateAction) {
         return new MoimMemberActionRequestDto(
                 moimId, memberId, moimMemberStateAction, MoimRoleType.NORMAL, "", true);
+    }
+
+    public static void truncateAllTable(JdbcTemplate jdbcTemplate) {
+
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
+
+        List<String> tableNames = List.of(
+                "category",
+                "moim_rule",
+                "rule_join",
+                "rule_persist",
+                "member",
+                "member_info",
+                "member_moim_linker",
+                "member_role_linker",
+                "member_schedule_linker",
+                "moim",
+                "moim_category_linker",
+                "moim_post",
+                "moim_review",
+                "post_comment",
+                "post_file",
+                "review_answer",
+                "schedule",
+                "role");
+
+        tableNames.forEach(tableName ->
+                jdbcTemplate.execute("TRUNCATE TABLE " + tableName));
+
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
     }
 
 }

--- a/src/test/java/com/peoplein/moiming/TestUtils.java
+++ b/src/test/java/com/peoplein/moiming/TestUtils.java
@@ -71,6 +71,7 @@ public class TestUtils {
     public static String postContent = "postContent";
     public static boolean isNotice = false;
     public static boolean hasFiles = false;
+    public static MoimPostCategory moimPostCategory = MoimPostCategory.GREETING;
 
 
     // moimService
@@ -89,14 +90,20 @@ public class TestUtils {
 
 
 
+    public static Member initOtherMemberAndMemberInfo() {
+        Role role = initUserRole();
+
+        Member member = Member.createMember("other" + uid
+                , "other" + password
+                , "other" + memberEmail
+                , "other" + memberName
+                , memberGender, role);
+        member.getMemberInfo().setMemberBirth(memberBirth);
+
+        return member;
+    }
 
     public static Member initMemberAndMemberInfo() {
-//        PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
-//        password = passwordEncoder.encode(password);
-//        MemberInfo memberInfo = new MemberInfo(memberEmail, memberName, memberGender);
-//        memberInfo.setMemberBirth(memberBirth);
-//        Member member = Member.createMember(uid, password, memberInfo);
-
         Role role = initAdminRole();
 
         Member member = Member.createMember(uid, password, memberEmail, memberName, memberGender, role);
@@ -104,14 +111,16 @@ public class TestUtils {
 
         return member;
 
-//        Role role = new Role(1L, "admin", RoleType.ADMIN);
-//        MemberRoleLinker memberRoleLinker = MemberRoleLinker.grantRoleToMember(member, role);
-//        return member;
     }
 
     public static Role initAdminRole() {
         return new Role(1L, "admin", RoleType.ADMIN);
     }
+
+    public static Role initUserRole() {
+        return new Role(2L, "admin", RoleType.USER);
+    }
+
 
 
     public static Moim initMoimAndRuleJoin() {
@@ -125,7 +134,7 @@ public class TestUtils {
     }
 
     public static MoimPost initMoimPost(Moim moim, Member member) {
-        return MoimPost.createMoimPost(postTitle, postContent, MoimPostCategory.EXTRA, isNotice, hasFiles, moim, member);
+        return MoimPost.createMoimPost(postTitle, postContent, moimPostCategory, isNotice, hasFiles, moim, member);
     }
 
     public static MoimDto initMoimDto() {

--- a/src/test/java/com/peoplein/moiming/TestUtils.java
+++ b/src/test/java/com/peoplein/moiming/TestUtils.java
@@ -91,16 +91,28 @@ public class TestUtils {
 
 
     public static Member initMemberAndMemberInfo() {
-        PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
-        password = passwordEncoder.encode(password);
-        MemberInfo memberInfo = new MemberInfo(memberEmail, memberName, memberGender);
-        memberInfo.setMemberBirth(memberBirth);
-        Member member = Member.createMember(uid, password, memberInfo);
+//        PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+//        password = passwordEncoder.encode(password);
+//        MemberInfo memberInfo = new MemberInfo(memberEmail, memberName, memberGender);
+//        memberInfo.setMemberBirth(memberBirth);
+//        Member member = Member.createMember(uid, password, memberInfo);
 
-        Role role = new Role(1L, "admin", RoleType.ADMIN);
-        MemberRoleLinker memberRoleLinker = MemberRoleLinker.grantRoleToMember(member, role);
+        Role role = initAdminRole();
+
+        Member member = Member.createMember(uid, password, memberEmail, memberName, memberGender, role);
+        member.getMemberInfo().setMemberBirth(memberBirth);
+
         return member;
+
+//        Role role = new Role(1L, "admin", RoleType.ADMIN);
+//        MemberRoleLinker memberRoleLinker = MemberRoleLinker.grantRoleToMember(member, role);
+//        return member;
     }
+
+    public static Role initAdminRole() {
+        return new Role(1L, "admin", RoleType.ADMIN);
+    }
+
 
     public static Moim initMoimAndRuleJoin() {
         Moim moim = Moim.createMoim(moimName, moimInfo, moimPfImg, new Area(areaState, areaCity), createdUid);

--- a/src/test/java/com/peoplein/moiming/domain/MemberTest.java
+++ b/src/test/java/com/peoplein/moiming/domain/MemberTest.java
@@ -46,6 +46,8 @@ public class MemberTest {
         // then
         assertThat(member.getUid()).isEqualTo(TestUtils.uid);
         assertThat(passwordEncoder.matches(expectedPassword, member.getPassword())).isTrue();
+        assertThat(role.getRoleType()).isEqualTo(role.getRoleType());
+        assertThat(member.getMemberInfo().getMemberName()).isEqualTo(TestUtils.memberName);
     }
 
     @Test

--- a/src/test/java/com/peoplein/moiming/domain/MemberTest.java
+++ b/src/test/java/com/peoplein/moiming/domain/MemberTest.java
@@ -1,6 +1,9 @@
 package com.peoplein.moiming.domain;
 
 import com.peoplein.moiming.TestUtils;
+import com.peoplein.moiming.domain.enums.RoleType;
+import com.peoplein.moiming.domain.fixed.Role;
+import com.peoplein.moiming.exception.BadAuthParameterInputException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -34,9 +37,11 @@ public class MemberTest {
         // given
         String expectedPassword = TestUtils.password;
         String encryptedPassword = passwordEncoder.encode(TestUtils.password);
+        Role role = new Role(1L, "admin", RoleType.ADMIN);
 
         // when
-        Member member = Member.createMember(TestUtils.uid, encryptedPassword, memberInfo);
+        Member member = Member.createMember(TestUtils.uid, encryptedPassword, TestUtils.memberEmail,
+                TestUtils.memberName, TestUtils.memberGender, role);
 
         // then
         assertThat(member.getUid()).isEqualTo(TestUtils.uid);
@@ -45,19 +50,31 @@ public class MemberTest {
 
     @Test
     void constructorFail() {
+        // given
+        Role role = TestUtils.initAdminRole();
+
         // when + then
-        assertThatThrownBy(() -> Member.createMember(null, password, memberInfo)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> Member.createMember("", password, memberInfo)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> Member.createMember(TestUtils.uid, null, memberInfo)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> Member.createMember(TestUtils.uid, "", memberInfo)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> Member.createMember(TestUtils.uid, password, null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> Member.createMember(
+                null, password, TestUtils.memberEmail, TestUtils.memberName, TestUtils.memberGender, role)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Member.createMember(
+                TestUtils.uid, null, TestUtils.memberEmail, TestUtils.memberName, TestUtils.memberGender, role)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Member.createMember(
+                TestUtils.uid, TestUtils.encryptedPassword, null, TestUtils.memberName, TestUtils.memberGender, role)).isInstanceOf(BadAuthParameterInputException.class);
+        assertThatThrownBy(() -> Member.createMember(
+                TestUtils.uid, TestUtils.encryptedPassword, TestUtils.memberEmail, null, TestUtils.memberGender, role)).isInstanceOf(BadAuthParameterInputException.class);
+        assertThatThrownBy(() -> Member.createMember(
+                TestUtils.uid, TestUtils.encryptedPassword, TestUtils.memberEmail, TestUtils.memberName, null, role)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> Member.createMember(
+                TestUtils.uid, TestUtils.encryptedPassword, TestUtils.memberEmail, TestUtils.memberName, TestUtils.memberGender, null)).isInstanceOf(NullPointerException.class);
     }
 
     @Test
     void refreshTokenSuccess() {
         // given
         String changedToken = "NEW_REFRESH_TOKEN";
-        Member member = Member.createMember(TestUtils.uid, password, memberInfo);
+        Role role = new Role(1L, "admin", RoleType.ADMIN);
+        Member member = Member.createMember(TestUtils.uid, TestUtils.password, TestUtils.memberEmail,
+                TestUtils.memberName, TestUtils.memberGender, role);
 
         // when
         member.changeRefreshToken(changedToken);
@@ -70,7 +87,9 @@ public class MemberTest {
     void refreshSameTokenSuccess() {
         // given
         String sameToken = TestUtils.refreshToken;
-        Member member = Member.createMember(TestUtils.uid, password, memberInfo);
+        Role role = new Role(1L, "admin", RoleType.ADMIN);
+        Member member = Member.createMember(TestUtils.uid, TestUtils.password, TestUtils.memberEmail,
+                TestUtils.memberName, TestUtils.memberGender, role);
 
         // when
         member.changeRefreshToken(sameToken);

--- a/src/test/java/com/peoplein/moiming/domain/MoimPostTest.java
+++ b/src/test/java/com/peoplein/moiming/domain/MoimPostTest.java
@@ -56,7 +56,6 @@ public class MoimPostTest {
         assertEquals(moimPostCategory, moimPost.getMoimPostCategory());
         assertEquals(isNotice, moimPost.isNotice());
         assertEquals(hasFiles, moimPost.isHasFiles());
-        assertNotNull(moimPost.getCreatedAt());
         assertNotNull(moimPost.getPostComments());
 
         // 메모리 할당 받은 객체들 그대로 반환

--- a/src/test/java/com/peoplein/moiming/domain/MoimPostTest.java
+++ b/src/test/java/com/peoplein/moiming/domain/MoimPostTest.java
@@ -1,5 +1,6 @@
 package com.peoplein.moiming.domain;
 
+import com.peoplein.moiming.TestUtils;
 import com.peoplein.moiming.domain.enums.MoimPostCategory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -137,5 +138,69 @@ public class MoimPostTest {
         assertThatThrownBy(() -> moimPost.addPostComment(postComment)).isInstanceOf(RuntimeException.class);
 
     }
+
+    @Test
+    void updateSuccessTestCase1() {
+        // given
+        Member member = TestUtils.initMemberAndMemberInfo();
+        Moim moim = TestUtils.createMoimOnly();
+        MoimPost moimPost = TestUtils.initMoimPost(moim, member);
+        Member updateMember = TestUtils.initOtherMemberAndMemberInfo();
+        String changedTitle = TestUtils.postTitle + "fixed";
+
+        // when
+        boolean update = moimPost.update(changedTitle,
+                TestUtils.postContent,
+                TestUtils.isNotice,
+                TestUtils.moimPostCategory,
+                updateMember.getUid());
+
+        // then
+        assertThat(update).isTrue();
+        assertThat(moimPost.getPostTitle()).isEqualTo(changedTitle);
+        assertThat(moimPost.getUpdatedUid()).isEqualTo(updateMember.getUid());
+    }
+
+    @Test
+    void updateSuccessTestCase2() {
+        // given
+        Member member = TestUtils.initMemberAndMemberInfo();
+        Moim moim = TestUtils.createMoimOnly();
+        MoimPost moimPost = TestUtils.initMoimPost(moim, member);
+        Member updateMember = TestUtils.initOtherMemberAndMemberInfo();
+
+        // when
+        boolean update = moimPost.update(TestUtils.postTitle,
+                TestUtils.postContent,
+                TestUtils.isNotice,
+                TestUtils.moimPostCategory,
+                updateMember.getUid());
+
+        // then
+        assertThat(update).isFalse();
+        assertThat(moimPost.getPostTitle()).isEqualTo(TestUtils.postTitle);
+        assertThat(moimPost.getUpdatedUid()).isEqualTo(member.getUid());
+    }
+
+    @Test
+    void updateFailTestCase1() {
+        // given
+        Member member = TestUtils.initMemberAndMemberInfo();
+        Moim moim = TestUtils.createMoimOnly();
+        MoimPost moimPost = TestUtils.initMoimPost(moim, member);
+
+        // when + then
+        assertThatThrownBy(() -> moimPost.update(null, null, false, null, null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> moimPost.update(TestUtils.postTitle, null, false, null, null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> moimPost.update(null, TestUtils.postContent, false, null, null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> moimPost.update(null, null, false, TestUtils.moimPostCategory, null))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> moimPost.update(null, null, false, null, TestUtils.uid + "updated"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
 
 }

--- a/src/test/java/com/peoplein/moiming/domain/MoimTest.java
+++ b/src/test/java/com/peoplein/moiming/domain/MoimTest.java
@@ -336,12 +336,18 @@ public class MoimTest {
 
 
     Member createMember(MemberGender memberGender, LocalDate memberBirth) {
-        MemberInfo memberInfo = new MemberInfo(TestUtils.memberEmail, TestUtils.memberName, memberGender);
-        memberInfo.setMemberBirth(memberBirth);
-        Member member = Member.createMember(TestUtils.uid, TestUtils.encryptedPassword, memberInfo);
+//        MemberInfo memberInfo = new MemberInfo(TestUtils.memberEmail, TestUtils.memberName, memberGender);
+//        memberInfo.setMemberBirth(memberBirth);
+//        Member member = Member.createMember(TestUtils.uid, TestUtils.encryptedPassword, memberInfo);
 
         Role role = new Role(1L, "admin", RoleType.USER);
-        MemberRoleLinker memberRoleLinker = MemberRoleLinker.grantRoleToMember(member, role);
+
+        Member member = Member.createMember(TestUtils.uid, TestUtils.password, TestUtils.memberEmail,
+                TestUtils.memberName, TestUtils.memberGender, role);
+
+        member.getMemberInfo().setMemberBirth(memberBirth);
+
+
         return member;
     }
 }

--- a/src/test/java/com/peoplein/moiming/integration/AuthIntegrationTest.java
+++ b/src/test/java/com/peoplein/moiming/integration/AuthIntegrationTest.java
@@ -36,6 +36,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+/**
+ * 인증 테스트는 SpringSecurityFilter에서 처리됨.
+ */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Transactional
 public class AuthIntegrationTest extends BaseTest {
@@ -62,6 +65,7 @@ public class AuthIntegrationTest extends BaseTest {
                 .build();
 
         url = "http://localhost:8080" + NetworkSetting.API_SERVER + NetworkSetting.API_AUTH_VER + NetworkSetting.API_AUTH;
+        // http://localhost:8080/api/v0/auth
     }
 
     private ObjectMapper om = new ObjectMapper()
@@ -161,7 +165,8 @@ public class AuthIntegrationTest extends BaseTest {
     @DisplayName("성공 @ /login")
     void 로그인() throws Exception {
         //given
-        MemberLoginDto memberLoginDto = new MemberLoginDto("wrock.kang", "1234");
+        MemberLoginDto memberLoginDto = new MemberLoginDto(TestUtils.uid,
+                TestUtils.password);
 
         //when
         url += "/login";

--- a/src/test/java/com/peoplein/moiming/integration/AuthIntegrationTest.java
+++ b/src/test/java/com/peoplein/moiming/integration/AuthIntegrationTest.java
@@ -3,10 +3,7 @@ package com.peoplein.moiming.integration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.peoplein.moiming.InitDatabaseQuery;
-import com.peoplein.moiming.NetworkSetting;
-import com.peoplein.moiming.TestHelper;
-import com.peoplein.moiming.TestUtils;
+import com.peoplein.moiming.*;
 import com.peoplein.moiming.domain.Member;
 import com.peoplein.moiming.model.ErrorResponse;
 import com.peoplein.moiming.model.ResponseModel;
@@ -24,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -40,7 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Transactional
-public class AuthIntegrationTest {
+public class AuthIntegrationTest extends BaseTest {
 
     @LocalServerPort
     private int port;

--- a/src/test/java/com/peoplein/moiming/integration/MoimIntegrationTest.java
+++ b/src/test/java/com/peoplein/moiming/integration/MoimIntegrationTest.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -48,7 +49,7 @@ import java.util.List;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Transactional
-public class MoimIntegrationTest {
+public class MoimIntegrationTest extends BaseTest {
 
     @LocalServerPort
     private int port;

--- a/src/test/java/com/peoplein/moiming/repository/jpa/MemberJpaRepositoryTest.java
+++ b/src/test/java/com/peoplein/moiming/repository/jpa/MemberJpaRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.peoplein.moiming.repository.jpa;
 
+import com.peoplein.moiming.BaseTest;
 import com.peoplein.moiming.TestUtils;
 import com.peoplein.moiming.domain.Member;
 import com.peoplein.moiming.domain.MemberInfo;
@@ -7,13 +8,17 @@ import com.peoplein.moiming.domain.MemberRoleLinker;
 import com.peoplein.moiming.repository.MemberRepository;
 import com.peoplein.moiming.repository.MemberRoleLinkerRepository;
 import com.peoplein.moiming.repository.RoleRepository;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
 
 import javax.persistence.EntityManager;
 
@@ -21,8 +26,9 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
-@Transactional(readOnly = true)
-public class MemberJpaRepositoryTest {
+@Transactional
+@Rollback(value = false)
+public class MemberJpaRepositoryTest extends BaseTest{
 
     @Autowired
     MemberRepository repository;
@@ -39,6 +45,7 @@ public class MemberJpaRepositoryTest {
 
     @BeforeEach
     void initInstance() {
+
         member = TestUtils.initMemberAndMemberInfo();
         memberInfo = member.getMemberInfo();
         MemberRoleLinker memberRoleLinker = member.getRoles().get(0);

--- a/src/test/java/com/peoplein/moiming/repository/jpa/MemberMoimLinkerJpaRepositoryTest.java
+++ b/src/test/java/com/peoplein/moiming/repository/jpa/MemberMoimLinkerJpaRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.peoplein.moiming.repository.jpa;
 
+import com.peoplein.moiming.BaseTest;
 import com.peoplein.moiming.TestUtils;
 import com.peoplein.moiming.domain.Member;
 import com.peoplein.moiming.domain.MemberMoimLinker;
@@ -14,6 +15,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
@@ -24,7 +27,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Transactional
-class MemberMoimLinkerJpaRepositoryTest {
+@Rollback(value = false)
+class MemberMoimLinkerJpaRepositoryTest extends BaseTest {
 
 
     @Autowired
@@ -42,14 +46,12 @@ class MemberMoimLinkerJpaRepositoryTest {
     @Autowired
     EntityManager em;
 
-
     Member member;
     Moim moim;
     MemberMoimLinker memberMoimLinker;
 
     @BeforeEach
     void initInstance() {
-
         member = TestUtils.initMemberAndMemberInfo();
         moim = TestUtils.initMoimAndRuleJoin();
         memberMoimLinker = MemberMoimLinker.memberJoinMoim(
@@ -62,6 +64,10 @@ class MemberMoimLinkerJpaRepositoryTest {
 
     @Test
     void saveTest() {
+
+        Long memberId = memberRepository.save(member);
+        Long moimId = moimRepository.save(moim);
+        Long roleId = roleRepository.save(member.getRoles().get(0).getRole());
 
         Long savedId = moimLinkerRepository.save(memberMoimLinker);
 

--- a/src/test/java/com/peoplein/moiming/repository/jpa/MoimJpaRepositoryTest.java
+++ b/src/test/java/com/peoplein/moiming/repository/jpa/MoimJpaRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.peoplein.moiming.repository.jpa;
 
+import com.peoplein.moiming.BaseTest;
 import com.peoplein.moiming.TestUtils;
 import com.peoplein.moiming.domain.Moim;
 import com.peoplein.moiming.domain.rules.MoimRule;
@@ -10,6 +11,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
@@ -19,7 +22,8 @@ import static org.junit.Assert.assertEquals;
 
 @SpringBootTest
 @Transactional
-public class MoimJpaRepositoryTest {
+@Rollback(value = false)
+public class MoimJpaRepositoryTest extends BaseTest {
 
     @Autowired
     private EntityManager em;

--- a/src/test/java/com/peoplein/moiming/repository/jpa/MoimPostJpaRepositoryTest.java
+++ b/src/test/java/com/peoplein/moiming/repository/jpa/MoimPostJpaRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.peoplein.moiming.repository.jpa;
 
+import com.peoplein.moiming.BaseTest;
 import com.peoplein.moiming.TestUtils;
 import com.peoplein.moiming.domain.*;
 import com.peoplein.moiming.repository.*;
@@ -7,6 +8,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
@@ -16,7 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Transactional
-class MoimPostJpaRepositoryTest {
+@Rollback(value = false)
+public class MoimPostJpaRepositoryTest extends BaseTest {
 
     @Autowired
     EntityManager em;

--- a/src/test/java/com/peoplein/moiming/repository/jpa/UtilsRepository.java
+++ b/src/test/java/com/peoplein/moiming/repository/jpa/UtilsRepository.java
@@ -56,14 +56,7 @@ public class UtilsRepository {
 
 
     public static Member initMemberAndMemberInfo() {
-//        PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
-//        password = passwordEncoder.encode(password);
-//        MemberInfo memberInfo = new MemberInfo(memberEmail, memberName, memberGender);
-//        Member member = Member.createMember(uid, password, memberInfo);
-
         Role role = new Role(1L, "admin", RoleType.ADMIN);
-//        MemberRoleLinker memberRoleLinker = MemberRoleLinker.grantRoleToMember(member, role);
-
         return Member.createMember(uid, password, memberEmail, memberName, memberGender, role);
     }
 

--- a/src/test/java/com/peoplein/moiming/repository/jpa/UtilsRepository.java
+++ b/src/test/java/com/peoplein/moiming/repository/jpa/UtilsRepository.java
@@ -56,14 +56,15 @@ public class UtilsRepository {
 
 
     public static Member initMemberAndMemberInfo() {
-        PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
-        password = passwordEncoder.encode(password);
-        MemberInfo memberInfo = new MemberInfo(memberEmail, memberName, memberGender);
-        Member member = Member.createMember(uid, password, memberInfo);
+//        PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+//        password = passwordEncoder.encode(password);
+//        MemberInfo memberInfo = new MemberInfo(memberEmail, memberName, memberGender);
+//        Member member = Member.createMember(uid, password, memberInfo);
 
         Role role = new Role(1L, "admin", RoleType.ADMIN);
-        MemberRoleLinker memberRoleLinker = MemberRoleLinker.grantRoleToMember(member, role);
-        return member;
+//        MemberRoleLinker memberRoleLinker = MemberRoleLinker.grantRoleToMember(member, role);
+
+        return Member.createMember(uid, password, memberEmail, memberName, memberGender, role);
     }
 
     public static Moim initMoim() {

--- a/src/test/java/com/peoplein/moiming/service/MoimMemberIntegrationServiceTest.java
+++ b/src/test/java/com/peoplein/moiming/service/MoimMemberIntegrationServiceTest.java
@@ -1,5 +1,6 @@
 package com.peoplein.moiming.service;
 
+import com.peoplein.moiming.BaseTest;
 import com.peoplein.moiming.TestUtils;
 import com.peoplein.moiming.domain.Member;
 import com.peoplein.moiming.domain.MemberMoimLinker;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
@@ -30,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest
 @Transactional
-public class MoimMemberIntegrationServiceTest {
+public class MoimMemberIntegrationServiceTest extends BaseTest {
 
 
     @Autowired
@@ -48,7 +50,6 @@ public class MoimMemberIntegrationServiceTest {
 
     @Autowired
     EntityManager em;
-
 
     @Test
     @DisplayName("성공 @ requestJoin() - RuleJoin이 없는 모임에 가입 요청")

--- a/src/test/java/com/peoplein/moiming/service/MoimMemberServiceTest.java
+++ b/src/test/java/com/peoplein/moiming/service/MoimMemberServiceTest.java
@@ -1,5 +1,6 @@
 package com.peoplein.moiming.service;
 
+import com.peoplein.moiming.BaseTest;
 import com.peoplein.moiming.TestHelper;
 import com.peoplein.moiming.TestUtils;
 import com.peoplein.moiming.domain.Member;

--- a/src/test/java/com/peoplein/moiming/service/MoimPostServiceTest.java
+++ b/src/test/java/com/peoplein/moiming/service/MoimPostServiceTest.java
@@ -1,4 +1,105 @@
 package com.peoplein.moiming.service;
 
-public class MoimPostServiceTest {
+import com.peoplein.moiming.BaseTest;
+import com.peoplein.moiming.TestUtils;
+import com.peoplein.moiming.domain.Member;
+import com.peoplein.moiming.domain.Moim;
+import com.peoplein.moiming.domain.MoimPost;
+import com.peoplein.moiming.model.dto.domain.MoimPostDto;
+import com.peoplein.moiming.model.dto.request.MoimPostRequestDto;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+public class MoimPostServiceTest extends BaseTest {
+
+    @Autowired
+    MoimPostService moimPostService;
+
+    @Autowired
+    EntityManager em;
+
+    @Test
+    void updateIntegrationSuccessTest() {
+        // given
+        Member member = TestUtils.initMemberAndMemberInfo();
+        Moim moim = TestUtils.createMoimOnly();
+        MoimPost moimPost = TestUtils.initMoimPost(moim, member);
+        String changedPostTitle = "fixed " + TestUtils.postTitle;
+
+        persist(member,
+                moim,
+                moimPost,
+                member.getRoles().get(0).getRole(),
+                member.getRoles().get(0));
+        flushAndClear();
+
+        MoimPostRequestDto moimPostRequestDto = new MoimPostRequestDto(
+                moim.getId(),
+                moimPost.getId(),
+                changedPostTitle,
+                TestUtils.postContent,
+                TestUtils.isNotice,
+                TestUtils.moimPostCategory);
+
+        // when
+        MoimPostDto moimPostDto = moimPostService.updatePost(moimPostRequestDto, member);
+
+        // then
+        assertThat(moimPostDto.getPostTitle()).isEqualTo(changedPostTitle);
+        assertThat(moimPostDto.getUpdatedUid()).isEqualTo(member.getUid());
+    }
+    @Test
+    void updateIntegrationFailTest() {
+        // 작성자만 수정 가능함.
+
+        // given
+        Member member = TestUtils.initMemberAndMemberInfo();
+        Member updateMember = TestUtils.initOtherMemberAndMemberInfo();
+        Moim moim = TestUtils.createMoimOnly();
+        MoimPost moimPost = TestUtils.initMoimPost(moim, member);
+        String changedPostTitle = "fixed " + TestUtils.postTitle;
+
+        persist(member,
+                moim,
+                moimPost,
+                updateMember,
+                member.getRoles().get(0).getRole(),
+                member.getRoles().get(0),
+                updateMember.getRoles().get(0).getRole(),
+                updateMember.getRoles().get(0));
+        flushAndClear();
+
+        MoimPostRequestDto moimPostRequestDto = new MoimPostRequestDto(
+                moim.getId(),
+                moimPost.getId(),
+                changedPostTitle,
+                TestUtils.postContent,
+                TestUtils.isNotice,
+                TestUtils.moimPostCategory);
+
+        // when + then
+        assertThatThrownBy(() -> moimPostService.updatePost(moimPostRequestDto, updateMember))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+
+    void flushAndClear() {
+        em.flush();
+        em.clear();
+    }
+
+    void persist(Object ... objects) {
+        Arrays.stream(objects).forEach(o -> em.persist(o));
+    }
 }

--- a/src/test/java/com/peoplein/moiming/service/MoimPostServiceUnitTest.java
+++ b/src/test/java/com/peoplein/moiming/service/MoimPostServiceUnitTest.java
@@ -1,5 +1,6 @@
 package com.peoplein.moiming.service;
 
+import com.peoplein.moiming.BaseTest;
 import com.peoplein.moiming.TestUtils;
 import com.peoplein.moiming.domain.Member;
 import com.peoplein.moiming.domain.Moim;
@@ -9,12 +10,14 @@ import com.peoplein.moiming.service.input.MoimPostServiceInput;
 import com.peoplein.moiming.service.output.MoimPostServiceOutput;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
-public class MoimPostServiceUnitTest {
+public class MoimPostServiceUnitTest extends BaseTest {
 
 
     MoimPostServiceCore moimPostServiceCore;

--- a/src/test/java/com/peoplein/moiming/service/MoimPostServiceUnitTest.java
+++ b/src/test/java/com/peoplein/moiming/service/MoimPostServiceUnitTest.java
@@ -55,4 +55,33 @@ public class MoimPostServiceUnitTest extends BaseTest {
         assertThat(output.getCreatedMoimPost().getMoim().getMoimName()).isEqualTo(moim.getMoimName());
         assertThat(output.getCreatedMoimPost().getMember().getUid()).isEqualTo(member.getUid());
     }
+
+    @Test
+    void deleteMoimPostTestPass() {
+        // given
+
+        Moim moim = TestUtils.initMoimAndRuleJoin();
+        Member member = TestUtils.initMemberAndMemberInfo();
+        MoimPostRequestDto moimPostRequestDto = TestUtils.initMoimPostRequestDto();
+        MoimPostServiceInput input = MoimPostServiceInput.builder()
+                .postTitleAboutNewMoimPost(moimPostRequestDto.getPostTitle())
+                .postContentAboutNewMoimPost(moimPostRequestDto.getPostContent())
+                .moimPostCategoryAboutNewMoimPost(moimPostRequestDto.getMoimPostCategory())
+                .isNoticeAboutNewMoimPost(moimPostRequestDto.isNotice())
+                .hasFilesAboutNewMoimPost(false)
+                .moimAboutNewMoimPost(moim)
+                .memberAboutNewMoimPost(member)
+                .build();
+
+        // when
+        MoimPostServiceOutput output = moimPostServiceCore.createMoimPost(input);
+
+        // then
+        assertThat(output.getCreatedMoimPost().getPostContent()).isEqualTo(input.getPostContentAboutNewMoimPost());
+        assertThat(output.getCreatedMoimPost().getPostTitle()).isEqualTo(input.getPostTitleAboutNewMoimPost());
+        assertThat(output.getCreatedMoimPost().getMoimPostCategory()).isEqualTo(input.getMoimPostCategoryAboutNewMoimPost());
+        assertThat(output.getCreatedMoimPost().getMoim().getMoimName()).isEqualTo(moim.getMoimName());
+        assertThat(output.getCreatedMoimPost().getMember().getUid()).isEqualTo(member.getUid());
+    }
+
 }

--- a/src/test/java/com/peoplein/moiming/service/MoimRulesServiceTest.java
+++ b/src/test/java/com/peoplein/moiming/service/MoimRulesServiceTest.java
@@ -1,5 +1,6 @@
 package com.peoplein.moiming.service;
 
+import com.peoplein.moiming.BaseTest;
 import com.peoplein.moiming.domain.Member;
 import com.peoplein.moiming.domain.MemberMoimLinker;
 import com.peoplein.moiming.domain.Moim;

--- a/src/test/java/com/peoplein/moiming/service/MoimServiceTest.java
+++ b/src/test/java/com/peoplein/moiming/service/MoimServiceTest.java
@@ -1,5 +1,6 @@
 package com.peoplein.moiming.service;
 
+import com.peoplein.moiming.BaseTest;
 import com.peoplein.moiming.TestUtils;
 import com.peoplein.moiming.domain.Member;
 import com.peoplein.moiming.domain.MemberMoimLinker;
@@ -29,7 +30,7 @@ import static org.mockito.Mockito.*;
 
 @SpringBootTest
 //@Transactional
-class MoimServiceTest {
+class MoimServiceTest extends BaseTest {
 
 
     @Mock

--- a/src/test/java/com/peoplein/moiming/service/MoimServiceUnitTest.java
+++ b/src/test/java/com/peoplein/moiming/service/MoimServiceUnitTest.java
@@ -1,5 +1,6 @@
 package com.peoplein.moiming.service;
 
+import com.peoplein.moiming.BaseTest;
 import com.peoplein.moiming.TestUtils;
 import com.peoplein.moiming.domain.Member;
 import com.peoplein.moiming.domain.Moim;
@@ -14,14 +15,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@SpringBootTest
-public class MoimServiceUnitTest {
+//@SpringBootTest
+public class MoimServiceUnitTest extends BaseTest {
 
     @Autowired
     MoimService moimService;

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -2,15 +2,15 @@ spring:
   #DB
   #Local DB Source
   datasource:
-    url: jdbc:h2:mem:testdb
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver
+    url: jdbc:mysql://localhost:${MYSQL_PORT}/test
+    username: testuser
+    password: testpass
+    driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
     hibernate:
       ddl-auto: create
-    database: h2
+    database: mysql
     properties:
       hibernate:
         show_sql: true


### PR DESCRIPTION
### Introduce `testContainers`
- 테스트 환경에서 Test Container를 이용하도록 했습니다. 이 커밋은 특정 테스트들은 테스트 시작할 때, Docker를 이용해 MySQL 컨테이너를 띄우고 이 컨테이너를 이용해 DB와의 기능이 정상 동작하는지 확인합니다
- MySQL 컨테이너를 사용하는 것은 H2 in-memory DB는 MySQL과 다르게 동작할 수 있기 때문입니다.
- 나중에 integration Test를 작성하실 때, 테스트 클래스에 extends BaseTest를 추가해주시면 자동으로 도커 컨테이너를 띄워서 테스트에 사용합니다. (필요하실 때 이용해주세요). 단, 반드시 `Docker Desktop`이 켜져있어야 정상적으로 동작합니다.


### AuthService Refactoring
- signin() 이 메서드를 리팩터링 했습니다. 이 메서드는 서비스 계층에 속해있는데, 도메인 객체 두 개를 생성하고 있습니다. Member, MemberLinker인데 Member를 생성할 때 MemberLinker까지 함께 생성되는 것이 더욱 캡슐화가 잘 된 것 같아, createMember쪽으로 MemberLinker 생성도 넘겼습니다. 
- 이 때 passwordencoder는 Member가 가지면 안되기 때문에 (웹 계층), 서비스 계층에서 인코딩한 비밀번호를 넘겨주도록 설정했습니다. 


### MoimPost에 BaseEntity 적용
- MoimPost에 BaseEntity 적용했습니다.


### MoimPostService.updatePost() 리팩토링 및 테스트코드 작성
- 초기화 할 때, 현재 녀석이 가장 최근에 업데이트 한 녀석이기 때문에 그 녀석의 아이디를 updateUid에 기록하게 해두었습니다.
- Change 되었는지를 판단하는 것은 Domain 계층에 있는 것이 좋은 것 같습니다. 따라서 MoimPostService에 있던 기능을 MoimPost로 넘겼습니다. 
- 관련해서 테스트 코드를 수정했습니다.


### MoimPostService의 deletePost 메서드 리팩터링 및 테스트 코드 작성
- CascadeType.ALL을 이용하고 있어서 N + 1 + 1 쿼리가 나가던 문제를 해결했습니다. 
- MemberMoimLinker의 연관 엔티티가 모두 Eager로 되어있어서, Lazy로 바꾸었습니다. 
- 관련된 테스트 코드를 작성했습니다. 
