### PR TITLE
정산활동 도메인 & 도메인 Dto & 생성 요청 관련

### DIFF
--- a/src/main/java/com/peoplein/moiming/InitDatabase.java
+++ b/src/main/java/com/peoplein/moiming/InitDatabase.java
@@ -137,5 +137,11 @@ public class InitDatabase {
     public void initReviewAnswers() {
         initDatabaseQuery.initReviewAnswers();
     }
+
+    @EventListener(ApplicationReadyEvent.class)
+    @Order(16)
+    public void initSessionCategories() {
+        initDatabaseQuery.initSessionCategories();
+    }
 }
 

--- a/src/main/java/com/peoplein/moiming/InitDatabaseQuery.java
+++ b/src/main/java/com/peoplein/moiming/InitDatabaseQuery.java
@@ -3,10 +3,7 @@ package com.peoplein.moiming;
 import com.peoplein.moiming.domain.*;
 import com.peoplein.moiming.domain.embeddable.Area;
 import com.peoplein.moiming.domain.enums.*;
-import com.peoplein.moiming.domain.fixed.Category;
-import com.peoplein.moiming.domain.fixed.QuestionChoice;
-import com.peoplein.moiming.domain.fixed.ReviewQuestion;
-import com.peoplein.moiming.domain.fixed.Role;
+import com.peoplein.moiming.domain.fixed.*;
 import com.peoplein.moiming.domain.rules.MoimRule;
 import com.peoplein.moiming.domain.rules.RuleJoin;
 import com.peoplein.moiming.domain.rules.RulePersist;
@@ -432,6 +429,20 @@ public class InitDatabaseQuery {
         em.persist(moimReview1);
         em.persist(moimReview2);
         em.persist(moimReview3);
+    }
+
+    public void initSessionCategories() {
+        SessionCategory sessionCategory1 = SessionCategory.createSessionCategory(SessionCategoryType.ACTIVITY);
+        SessionCategory sessionCategory2= SessionCategory.createSessionCategory(SessionCategoryType.FOOD);
+        SessionCategory sessionCategory3 = SessionCategory.createSessionCategory(SessionCategoryType.ALCOHOL);
+        SessionCategory sessionCategory4 = SessionCategory.createSessionCategory(SessionCategoryType.DRINKS);
+        SessionCategory sessionCategory5 = SessionCategory.createSessionCategory(SessionCategoryType.EXTRA);
+
+        em.persist(sessionCategory1);
+        em.persist(sessionCategory2);
+        em.persist(sessionCategory3);
+        em.persist(sessionCategory4);
+        em.persist(sessionCategory5);
     }
 
     private ReviewQuestion findReviewQuestion(List<ReviewQuestion> reviewQuestions, QuestionName questionName) {

--- a/src/main/java/com/peoplein/moiming/controller/MoimSessionController.java
+++ b/src/main/java/com/peoplein/moiming/controller/MoimSessionController.java
@@ -4,16 +4,16 @@ package com.peoplein.moiming.controller;
 import com.peoplein.moiming.NetworkSetting;
 import com.peoplein.moiming.domain.Member;
 import com.peoplein.moiming.model.ResponseModel;
+import com.peoplein.moiming.model.dto.domain.MoimSessionDto;
 import com.peoplein.moiming.model.dto.request.MoimSessionRequestDto;
 import com.peoplein.moiming.model.dto.response.MoimSessionResponseDto;
 import com.peoplein.moiming.service.MoimSessionService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -34,12 +34,22 @@ public class MoimSessionController {
     }
 
     /*
-     모임 내 모든 정산활동 기본 정보 조회 - moim/session/moimId={}
+     모임 내 모든 정산활동 기본 정보 조회 - moim/session?moimId={}
      */
+    @GetMapping("")
+    public List<MoimSessionDto> getAllMoimSessions(@RequestParam(name = "moimId") Long moimId) {
+        Member curMember = (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return moimSessionService.getAllMoimSessions(moimId, curMember);
+    }
 
-    /*
+    /*s
      특정 정산활동 세부조회 - moim/session/{sessionId}
      */
+    @GetMapping("/{sessionId}")
+    public MoimSessionResponseDto getMoimSession(@PathVariable(name = "sessionId") Long sessionId) {
+        Member curMember = (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return moimSessionService.getMoimSession(sessionId, curMember);
+    }
 
     /*
      정산활동 수정

--- a/src/main/java/com/peoplein/moiming/controller/MoimSessionController.java
+++ b/src/main/java/com/peoplein/moiming/controller/MoimSessionController.java
@@ -54,13 +54,14 @@ public class MoimSessionController {
     /*
      정산활동 수정
      */
+    @PatchMapping("/update")
+    public void updateMoimSession(@RequestBody MoimSessionRequestDto moimSessionRequestDto) {
+        Member curMember = (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        moimSessionService.updateMoimSession(moimSessionRequestDto, curMember);
+    }
 
     /*
      정산활동 삭제
-     */
-
-    /*
-
      */
 
 

--- a/src/main/java/com/peoplein/moiming/controller/MoimSessionController.java
+++ b/src/main/java/com/peoplein/moiming/controller/MoimSessionController.java
@@ -2,8 +2,16 @@ package com.peoplein.moiming.controller;
 
 
 import com.peoplein.moiming.NetworkSetting;
+import com.peoplein.moiming.domain.Member;
+import com.peoplein.moiming.model.ResponseModel;
+import com.peoplein.moiming.model.dto.request.MoimSessionRequestDto;
+import com.peoplein.moiming.model.dto.response.MoimSessionResponseDto;
+import com.peoplein.moiming.service.MoimSessionService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -13,12 +21,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(NetworkSetting.API_SERVER + NetworkSetting.API_MOIM_VER + NetworkSetting.API_MOIM + NetworkSetting.API_MOIM_SESSION)
 public class MoimSessionController {
 
+    private final MoimSessionService moimSessionService;
+
     /*
      정산활동 생성 - create
      */
+    @PostMapping("/create")
+    public ResponseModel<MoimSessionResponseDto> createMoimSession(@RequestBody MoimSessionRequestDto moimSessionRequestDto) {
+        Member curMember = (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        MoimSessionResponseDto moimSessionResponseDto = moimSessionService.createMoimSession(moimSessionRequestDto, curMember);
+        return ResponseModel.createResponse(moimSessionResponseDto);
+    }
 
     /*
-     모임 내 모든 정산활동 조회 - moim/session/moimId={}
+     모임 내 모든 정산활동 기본 정보 조회 - moim/session/moimId={}
      */
 
     /*
@@ -26,7 +42,20 @@ public class MoimSessionController {
      */
 
     /*
+     정산활동 수정
+     */
 
+    /*
+     정산활동 삭제
+     */
+
+    /*
+
+     */
+
+
+    /*
+     FCM : 송금 요청
      */
 
 }

--- a/src/main/java/com/peoplein/moiming/domain/enums/MemberSessionState.java
+++ b/src/main/java/com/peoplein/moiming/domain/enums/MemberSessionState.java
@@ -1,0 +1,8 @@
+package com.peoplein.moiming.domain.enums;
+
+public enum MemberSessionState {
+
+    SENT,
+    UNSENT,
+    CHECKING
+}

--- a/src/main/java/com/peoplein/moiming/domain/enums/SessionCategoryType.java
+++ b/src/main/java/com/peoplein/moiming/domain/enums/SessionCategoryType.java
@@ -1,0 +1,10 @@
+package com.peoplein.moiming.domain.enums;
+
+public enum SessionCategoryType {
+
+    ACTIVITY, // 활동
+    FOOD, // 음식
+    ALCOHOL, // 주류
+    DRINKS, // 음료
+
+}

--- a/src/main/java/com/peoplein/moiming/domain/enums/SessionCategoryType.java
+++ b/src/main/java/com/peoplein/moiming/domain/enums/SessionCategoryType.java
@@ -6,5 +6,5 @@ public enum SessionCategoryType {
     FOOD, // 음식
     ALCOHOL, // 주류
     DRINKS, // 음료
-
+    EXTRA
 }

--- a/src/main/java/com/peoplein/moiming/domain/fixed/SessionCategory.java
+++ b/src/main/java/com/peoplein/moiming/domain/fixed/SessionCategory.java
@@ -1,6 +1,7 @@
 package com.peoplein.moiming.domain.fixed;
 
 
+import com.peoplein.moiming.domain.DomainChecker;
 import com.peoplein.moiming.domain.enums.SessionCategoryType;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -29,5 +30,20 @@ public class SessionCategory {
 
     private LocalDateTime updatedAt;
 
+    public static SessionCategory createSessionCategory(SessionCategoryType categoryType) {
+        SessionCategory sessionCategory = new SessionCategory(categoryType);
+        return sessionCategory;
+    }
+
+    private SessionCategory(SessionCategoryType categoryType) {
+
+        DomainChecker.checkWrongObjectParams(this.getClass().getName(), categoryType);
+        this.categoryType = categoryType;
+
+        // 초기화
+        this.isUsing = true;
+        this.createdAt = LocalDateTime.now();
+
+    }
 
 }

--- a/src/main/java/com/peoplein/moiming/domain/fixed/SessionCategory.java
+++ b/src/main/java/com/peoplein/moiming/domain/fixed/SessionCategory.java
@@ -1,0 +1,33 @@
+package com.peoplein.moiming.domain.fixed;
+
+
+import com.peoplein.moiming.domain.enums.SessionCategoryType;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "session_category")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SessionCategory {
+
+    @Id
+    @Column(name = "session_category_id")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long id;
+
+    @Enumerated(value = EnumType.STRING)
+    private SessionCategoryType categoryType;
+
+    private boolean isUsing;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+
+}

--- a/src/main/java/com/peoplein/moiming/domain/session/MemberSessionCategoryLinker.java
+++ b/src/main/java/com/peoplein/moiming/domain/session/MemberSessionCategoryLinker.java
@@ -1,0 +1,36 @@
+package com.peoplein.moiming.domain.session;
+
+
+import com.peoplein.moiming.domain.fixed.SessionCategory;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Table(name = "member_session_category_linker")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberSessionCategoryLinker {
+
+    @Id
+    @Column(name = "member_session_category_linker_id")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long id;
+
+
+    /*
+     관리 대상이 아니므로,
+     create, update 에 관한 필드도 불필요
+     */
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_session_linker_id")
+    private MemberSessionLinker memberSessionLinker;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_category_id")
+    private SessionCategory sessionCategory;
+
+}

--- a/src/main/java/com/peoplein/moiming/domain/session/MemberSessionCategoryLinker.java
+++ b/src/main/java/com/peoplein/moiming/domain/session/MemberSessionCategoryLinker.java
@@ -1,6 +1,7 @@
 package com.peoplein.moiming.domain.session;
 
 
+import com.peoplein.moiming.domain.DomainChecker;
 import com.peoplein.moiming.domain.fixed.SessionCategory;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -19,7 +20,6 @@ public class MemberSessionCategoryLinker {
     @GeneratedValue(strategy = GenerationType.SEQUENCE)
     private Long id;
 
-
     /*
      관리 대상이 아니므로,
      create, update 에 관한 필드도 불필요
@@ -32,5 +32,15 @@ public class MemberSessionCategoryLinker {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "session_category_id")
     private SessionCategory sessionCategory;
+
+
+    public MemberSessionCategoryLinker(MemberSessionLinker memberSessionLinker, SessionCategory sessionCategory) {
+        DomainChecker.checkWrongObjectParams(this.getClass().getName(), memberSessionLinker, sessionCategory);
+
+        this.memberSessionLinker = memberSessionLinker;
+        this.sessionCategory = sessionCategory;
+        this.memberSessionLinker.getMemberSessionCategoryLinkers().add(this);
+    }
+
 
 }

--- a/src/main/java/com/peoplein/moiming/domain/session/MemberSessionLinker.java
+++ b/src/main/java/com/peoplein/moiming/domain/session/MemberSessionLinker.java
@@ -1,0 +1,51 @@
+package com.peoplein.moiming.domain.session;
+
+
+import com.peoplein.moiming.domain.Member;
+import com.peoplein.moiming.domain.enums.MemberSessionState;
+import com.peoplein.moiming.domain.fixed.SessionCategory;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "member_session_linker")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberSessionLinker {
+
+    @Id
+    @Column(name = "member_session_linker_id")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long id;
+
+    private int singleCost;
+
+    @Enumerated(value = EnumType.STRING)
+    private MemberSessionState memberSessionState;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "moim_session_id")
+    private MoimSession moimSession;
+
+    /*
+     멤버가 해당 정산에 참여해야 하는 정산 Category 들과의 연결자들
+     TODO 바로 List<Category> 가 될 수 있는 방법은 ..
+     */
+    @OneToMany(mappedBy = "memberSessionLinker")
+    private List<MemberSessionCategoryLinker> memberSessionCategoryLinkers = new ArrayList<>();
+}

--- a/src/main/java/com/peoplein/moiming/domain/session/MoimSession.java
+++ b/src/main/java/com/peoplein/moiming/domain/session/MoimSession.java
@@ -1,6 +1,7 @@
 package com.peoplein.moiming.domain.session;
 
 
+import com.peoplein.moiming.domain.DomainChecker;
 import com.peoplein.moiming.domain.Moim;
 import com.peoplein.moiming.domain.Schedule;
 import lombok.AccessLevel;
@@ -9,6 +10,8 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -21,6 +24,8 @@ public class MoimSession {
     @GeneratedValue(strategy = GenerationType.SEQUENCE)
     private Long id;
 
+    private String sessionName;
+    private String sessionInfo;
     private int totalCost;
 
     private int curCost;
@@ -30,8 +35,10 @@ public class MoimSession {
     private int curSenderCount;
 
     private LocalDateTime createdAt;
+    private String createdUid;
 
     private LocalDateTime updatedAt;
+    private String updatedUid;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "moim_id")
@@ -44,5 +51,50 @@ public class MoimSession {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "schedule_id")
     private Schedule schedule;
+
+    /*
+     다대다 연관관계 매핑
+     */
+    @OneToMany(mappedBy = "moimSession", cascade = CascadeType.ALL)
+    private List<SessionCategoryItem> sessionCategoryItems = new ArrayList<>();
+
+    @OneToMany(mappedBy = "moimSession", cascade = CascadeType.ALL)
+    private List<MemberSessionLinker> memberSessionLinkers = new ArrayList<>();
+
+
+    public static MoimSession createMoimSession(String sessionName, String sessionInfo, int totalCost, int totalSenderCount, String createdUid
+            , Moim moim, Schedule schedule) {
+        MoimSession moimSession = new MoimSession(
+                sessionName, sessionInfo, totalCost, totalSenderCount, createdUid, moim, schedule
+        );
+
+        return moimSession;
+    }
+
+
+    private MoimSession(String sessionName, String sessionInfo, int totalCost, int totalSenderCount, String createdUid
+            , Moim moim, Schedule schedule) {
+
+        // NN 검증
+        DomainChecker.checkRightString(this.getClass().getName(), false, sessionName, createdUid);
+        DomainChecker.checkWrongObjectParams(this.getClass().getName(), moim);
+
+        // 생성
+        this.sessionName = sessionName;
+        this.sessionInfo = sessionInfo;
+        this.totalCost = totalCost;
+        this.totalSenderCount = totalSenderCount;
+        this.createdUid = createdUid;
+
+        // 초기화
+        this.curCost = 0;
+        this.curSenderCount = 0;
+        this.createdAt = LocalDateTime.now();
+
+        // 연관관계 매핑
+        this.moim = moim;
+        this.schedule = schedule;
+    }
+
 
 }

--- a/src/main/java/com/peoplein/moiming/domain/session/MoimSession.java
+++ b/src/main/java/com/peoplein/moiming/domain/session/MoimSession.java
@@ -1,0 +1,48 @@
+package com.peoplein.moiming.domain.session;
+
+
+import com.peoplein.moiming.domain.Moim;
+import com.peoplein.moiming.domain.Schedule;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "moim_session")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MoimSession {
+
+    @Id
+    @Column(name = "moim_session_id")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long id;
+
+    private int totalCost;
+
+    private int curCost;
+
+    private int totalSenderCount;
+
+    private int curSenderCount;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "moim_id")
+    private Moim moim;
+
+    /*
+     @Nullable
+     특정 일정에 대한 정산활동일 수도 있고, 아닐 수도 있다
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedule_id")
+    private Schedule schedule;
+
+}

--- a/src/main/java/com/peoplein/moiming/domain/session/SessionCategoryItem.java
+++ b/src/main/java/com/peoplein/moiming/domain/session/SessionCategoryItem.java
@@ -1,0 +1,43 @@
+package com.peoplein.moiming.domain.session;
+
+
+import com.peoplein.moiming.domain.enums.SessionCategoryType;
+import com.peoplein.moiming.domain.fixed.SessionCategory;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "session_category_item")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SessionCategoryItem {
+
+    public final String DEFAULT_ITEM_NAME = "DEFAULT";
+
+    @Id
+    @Column(name = "session_category_item_id")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    private Long id;
+
+    private String itemName;
+
+    private int itemCost;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "moim_session_id")
+    private MoimSession moimSession;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_category_id")
+    private SessionCategory sessionCategory;
+
+}

--- a/src/main/java/com/peoplein/moiming/domain/session/SessionCategoryItem.java
+++ b/src/main/java/com/peoplein/moiming/domain/session/SessionCategoryItem.java
@@ -1,6 +1,7 @@
 package com.peoplein.moiming.domain.session;
 
 
+import com.peoplein.moiming.domain.DomainChecker;
 import com.peoplein.moiming.domain.enums.SessionCategoryType;
 import com.peoplein.moiming.domain.fixed.SessionCategory;
 import lombok.AccessLevel;
@@ -16,7 +17,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SessionCategoryItem {
 
-    public final String DEFAULT_ITEM_NAME = "DEFAULT";
+    public static final String DEFAULT_ITEM_NAME = "DEFAULT";
 
     @Id
     @Column(name = "session_category_item_id")
@@ -39,5 +40,30 @@ public class SessionCategoryItem {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "session_category_id")
     private SessionCategory sessionCategory;
+
+    public static SessionCategoryItem createSessionCategoryItem(String itemName, int itemCost, MoimSession moimSession, SessionCategory sessionCategory) {
+
+        SessionCategoryItem sessionCategoryItem = new SessionCategoryItem(itemName, itemCost, moimSession, sessionCategory);
+        return sessionCategoryItem;
+    }
+
+
+    private SessionCategoryItem(String itemName, int itemCost, MoimSession moimSession, SessionCategory sessionCategory) {
+
+        //NN 체킹
+        DomainChecker.checkRightString(this.getClass().getName(), false, itemName);
+        DomainChecker.checkWrongObjectParams(this.getClass().getName(), moimSession, sessionCategory);
+
+        this.itemName = itemName;
+        this.itemCost = itemCost;
+
+        // 초기화
+        this.createdAt = LocalDateTime.now();
+
+        // 연관관계 매핑
+        this.moimSession = moimSession;
+        this.sessionCategory = sessionCategory;
+        this.moimSession.getSessionCategoryItems().add(this);
+    }
 
 }

--- a/src/main/java/com/peoplein/moiming/model/dto/SessionCategoryDetailsDto.java
+++ b/src/main/java/com/peoplein/moiming/model/dto/SessionCategoryDetailsDto.java
@@ -1,0 +1,32 @@
+package com.peoplein.moiming.model.dto;
+
+import com.peoplein.moiming.domain.enums.SessionCategoryType;
+import com.peoplein.moiming.model.dto.domain.SessionCategoryItemDto;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SessionCategoryDetailsDto {
+
+    private SessionCategoryType sessionCategoryType;
+    private int categoryTotalCost; // 요청시 정합성 검증용, 따로 저장 및 응답 X
+    private List<SessionCategoryItemDto> sessionCategoryItems = new ArrayList<>();
+
+    /*
+     Constructor -1
+     응답용 ReponseModel
+     */
+    public SessionCategoryDetailsDto(SessionCategoryType sessionCategoryType, List<SessionCategoryItemDto> sessionCategoryItems) {
+        this.sessionCategoryType = sessionCategoryType;
+        this.sessionCategoryItems = sessionCategoryItems;
+    }
+
+
+}

--- a/src/main/java/com/peoplein/moiming/model/dto/domain/MemberSessionLinkerDto.java
+++ b/src/main/java/com/peoplein/moiming/model/dto/domain/MemberSessionLinkerDto.java
@@ -1,0 +1,33 @@
+package com.peoplein.moiming.model.dto.domain;
+
+import com.peoplein.moiming.domain.enums.SessionCategoryType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class MemberSessionLinkerDto {
+
+    private Long memberId;
+    private int singleCost;
+    private List<SessionCategoryType> sessionCategoryTypes = new ArrayList<>();
+
+    // MEMO:: 생성 요청시에는 없음, 전송시 필요 정보
+    private MoimMemberInfoDto moimMemberInfoDto;
+
+    /*
+     Constructor -1
+     응답용 Dto 형성시 필요 정보들을 토대로 Dto 형성
+     */
+    public MemberSessionLinkerDto(Long memberId, int singleCost, List<SessionCategoryType> sessionCategoryTypes, MoimMemberInfoDto moimMemberInfoDto) {
+
+        this.memberId = memberId;
+        this.singleCost = singleCost;
+        this.sessionCategoryTypes = sessionCategoryTypes;
+        this.moimMemberInfoDto = moimMemberInfoDto;
+    }
+
+}

--- a/src/main/java/com/peoplein/moiming/model/dto/domain/MoimSessionDto.java
+++ b/src/main/java/com/peoplein/moiming/model/dto/domain/MoimSessionDto.java
@@ -1,0 +1,64 @@
+package com.peoplein.moiming.model.dto.domain;
+
+import com.peoplein.moiming.domain.session.MoimSession;
+import com.peoplein.moiming.model.dto.response.MoimSessionResponseDto;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MoimSessionDto {
+
+
+    private Long moimId;
+    private Long scheduleId; // Nullable
+    private String sessionName;
+    private String sessionInfo;
+    private int totalCost;
+    private int totalSenderCount;
+
+    /*
+     생성 요청 시에는 부재인 정보들
+     */
+    private Long sessionId;
+    private int curCost;
+    private int curSenderCount;
+    private LocalDateTime createdAt;
+    private String createdUid;
+    private LocalDateTime updatedAt;
+    private String updatedUid;
+
+    /*
+     요청시 사용 X, 응답시에는 moimId, scheduleId 필요하지 않는다
+     MoimSession 도메인 정보를 가지고 DTO 를 만들어내는 Constructor
+     */
+    public MoimSessionDto(MoimSession moimSession) {
+        this.sessionId = moimSession.getId();
+        this.sessionName = moimSession.getSessionName();
+        this.sessionInfo = moimSession.getSessionInfo();
+        this.totalCost = moimSession.getTotalCost();
+        this.totalSenderCount = moimSession.getTotalSenderCount();
+        this.curCost = moimSession.getCurCost();
+        this.curSenderCount = moimSession.getCurSenderCount();
+        this.createdAt = moimSession.getCreatedAt();
+        this.createdUid = moimSession.getCreatedUid();
+        this.updatedAt = moimSession.getUpdatedAt();
+        this.updatedUid = moimSession.getUpdatedUid();
+    }
+
+//    /*
+//     Constructor -2
+//     요청 Object Mapper 를 위한 생성자
+//     */
+//    public MoimSessionDto(Long moimId, Long scheduleId, String sessionName, String sessionInfo, int totalCost, int totalSenderCount) {
+//        this.moimId = moimId;
+//        this.scheduleId = scheduleId;
+//        this.sessionName = sessionName;
+//        this.sessionInfo = sessionInfo;
+//        this.totalCost = totalCost;
+//        this.totalSenderCount = totalSenderCount;
+//    }
+}

--- a/src/main/java/com/peoplein/moiming/model/dto/domain/ScheduleDto.java
+++ b/src/main/java/com/peoplein/moiming/model/dto/domain/ScheduleDto.java
@@ -1,5 +1,6 @@
 package com.peoplein.moiming.model.dto.domain;
 
+import com.peoplein.moiming.domain.Schedule;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -21,4 +22,21 @@ public class ScheduleDto {
     private String createdUid;
     private LocalDateTime updatedAt;
     private String updatedUid;
+
+    /*
+     Constructor 1
+     Entity 로 Domain Dto 만들기
+     */
+    public ScheduleDto(Schedule schedule) {
+        this.scheduleId = schedule.getId();
+        this.scheduleTitle = schedule.getScheduleTitle();
+        this.scheduleLocation = schedule.getScheduleLocation();
+        this.scheduleDate = schedule.getScheduleDate();
+        this.maxCount = schedule.getMaxCount();
+        this.isClosed = schedule.isClosed();
+        this.createdAt = schedule.getCreatedAt();
+        this.createdUid = schedule.getCreatedUid();
+        this.updatedAt = schedule.getUpdatedAt();
+        this.updatedUid = schedule.getUpdatedUid();
+    }
 }

--- a/src/main/java/com/peoplein/moiming/model/dto/domain/SessionCategoryItemDto.java
+++ b/src/main/java/com/peoplein/moiming/model/dto/domain/SessionCategoryItemDto.java
@@ -1,0 +1,33 @@
+package com.peoplein.moiming.model.dto.domain;
+
+import com.peoplein.moiming.domain.session.SessionCategoryItem;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class SessionCategoryItemDto {
+
+    private Long itemId; // 요청시 부재
+    private String itemName;
+    private int itemCost;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    /*
+     Constructor - 1
+     Entity 를 통해 Domain Dto 를 형성
+     */
+    public SessionCategoryItemDto(SessionCategoryItem sessionCategoryItem) {
+
+        this.itemId = sessionCategoryItem.getId();
+        this.itemName = sessionCategoryItem.getItemName();
+        this.itemCost = sessionCategoryItem.getItemCost();
+        this.createdAt = sessionCategoryItem.getCreatedAt();
+        this.updatedAt = sessionCategoryItem.getUpdatedAt();
+
+    }
+
+}

--- a/src/main/java/com/peoplein/moiming/model/dto/request/MoimSessionRequestDto.java
+++ b/src/main/java/com/peoplein/moiming/model/dto/request/MoimSessionRequestDto.java
@@ -1,0 +1,30 @@
+package com.peoplein.moiming.model.dto.request;
+
+import com.peoplein.moiming.model.dto.SessionCategoryDetailsDto;
+import com.peoplein.moiming.model.dto.domain.MemberSessionLinkerDto;
+import com.peoplein.moiming.model.dto.domain.MoimSessionDto;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MoimSessionRequestDto {
+
+    // Session 기본 정보
+    private MoimSessionDto moimSessionDto;
+
+    //
+    // 정산 항목을 받아야 하고 * MoimSessionCategoryLinker
+    // 정산 항목 내부에 하위 카테고리로 정산 품목들이 List 로 들어와있어야 한다
+    private List<SessionCategoryDetailsDto> sessionCategoryDetailsDtos = new ArrayList<>();
+
+    // 정산에 참여중인 멤버
+    // 해당 정산에 참여하는 멤버가 있으면, 그 정보 안에 생성자도 있다면 동일한 기준으로 들어가 있다.
+    // 해당 MemberSessionLinkerDto 에는 SessionCategory 가 List 로 같이 들어가 있을 것이다.
+    private List<MemberSessionLinkerDto> memberSessionLinkerDtos = new ArrayList<>();
+
+}

--- a/src/main/java/com/peoplein/moiming/model/dto/response/MoimSessionResponseDto.java
+++ b/src/main/java/com/peoplein/moiming/model/dto/response/MoimSessionResponseDto.java
@@ -1,0 +1,32 @@
+package com.peoplein.moiming.model.dto.response;
+
+import com.peoplein.moiming.model.dto.SessionCategoryDetailsDto;
+import com.peoplein.moiming.model.dto.domain.MemberSessionLinkerDto;
+import com.peoplein.moiming.model.dto.domain.MoimSessionDto;
+import com.peoplein.moiming.model.dto.domain.ScheduleDto;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MoimSessionResponseDto {
+
+    // MoimSession 기본 정보
+    private MoimSessionDto moimSessionDto;
+
+    // 없으면 Null 반환
+    private ScheduleDto scheduleDto;
+
+    // SessionItemCategory 정보
+    private List<SessionCategoryDetailsDto> sessionCategoryDetailsDtos = new ArrayList<>();
+
+    // MemberSessionLinker & MemberMoimInfoDto 정보
+    private List<MemberSessionLinkerDto> memberSessionLinkerDtos = new ArrayList<>();
+
+}

--- a/src/main/java/com/peoplein/moiming/repository/MemberRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/MemberRepository.java
@@ -22,4 +22,6 @@ public interface MemberRepository {
 
     Member findMemberAndMemberInfoWithRolesById(Long id);
 
+    List<Member> findMembersByIds(List<Long> memberIds);
+
 }

--- a/src/main/java/com/peoplein/moiming/repository/MoimSessionRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/MoimSessionRepository.java
@@ -1,0 +1,11 @@
+package com.peoplein.moiming.repository;
+
+import com.peoplein.moiming.domain.session.MoimSession;
+
+import java.util.Optional;
+
+public interface MoimSessionRepository {
+
+    Long save(MoimSession moimSession);
+    Optional<MoimSession> findOptionalById(Long sessionId);
+}

--- a/src/main/java/com/peoplein/moiming/repository/MoimSessionRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/MoimSessionRepository.java
@@ -2,10 +2,12 @@ package com.peoplein.moiming.repository;
 
 import com.peoplein.moiming.domain.session.MoimSession;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MoimSessionRepository {
 
     Long save(MoimSession moimSession);
     Optional<MoimSession> findOptionalById(Long sessionId);
+    List<MoimSession> findAllByMoimId(Long moimId);
 }

--- a/src/main/java/com/peoplein/moiming/repository/ScheduleRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/ScheduleRepository.java
@@ -4,12 +4,15 @@ import com.peoplein.moiming.domain.MoimPost;
 import com.peoplein.moiming.domain.Schedule;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ScheduleRepository {
 
     Long save(Schedule schedule);
 
     Schedule findById(Long scheduleId);
+
+    Optional<Schedule> findOptionalById(Long scheduleId);
 
     Schedule findWithMoimById(Long scheduleId);
 

--- a/src/main/java/com/peoplein/moiming/repository/SessionCategoryRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/SessionCategoryRepository.java
@@ -1,0 +1,11 @@
+package com.peoplein.moiming.repository;
+
+import com.peoplein.moiming.domain.fixed.SessionCategory;
+
+import java.util.List;
+
+public interface SessionCategoryRepository {
+
+    List<SessionCategory> findAllSessionCategories();
+
+}

--- a/src/main/java/com/peoplein/moiming/repository/jpa/MemberJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/MemberJpaRepository.java
@@ -111,4 +111,11 @@ public class MemberJpaRepository implements MemberRepository {
                 .fetchOne();
     }
 
+    @Override
+    public List<Member> findMembersByIds(List<Long> memberIds) {
+        return queryFactory.selectFrom(member)
+                .where(member.id.in(memberIds))
+                .fetch();
+    }
+
 }

--- a/src/main/java/com/peoplein/moiming/repository/jpa/MoimSessionJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/MoimSessionJpaRepository.java
@@ -7,9 +7,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
+import java.util.List;
 import java.util.Optional;
 
 import static com.peoplein.moiming.domain.session.QMoimSession.*;
+import static com.peoplein.moiming.domain.QSchedule.*;
 
 @Repository
 @RequiredArgsConstructor
@@ -28,7 +30,15 @@ public class MoimSessionJpaRepository implements MoimSessionRepository {
     @Override
     public Optional<MoimSession> findOptionalById(Long sessionId) {
         return Optional.ofNullable(queryFactory.selectFrom(moimSession)
+                .join(moimSession.schedule, schedule).fetchJoin()
                 .where(moimSession.id.eq(sessionId))
                 .fetchOne());
+    }
+
+    @Override
+    public List<MoimSession> findAllByMoimId(Long moimId) {
+        return queryFactory.selectFrom(moimSession)
+                .where(moimSession.moim.id.eq(moimId))
+                .fetch();
     }
 }

--- a/src/main/java/com/peoplein/moiming/repository/jpa/MoimSessionJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/MoimSessionJpaRepository.java
@@ -1,0 +1,34 @@
+package com.peoplein.moiming.repository.jpa;
+
+import com.peoplein.moiming.domain.session.MoimSession;
+import com.peoplein.moiming.repository.MoimSessionRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.Optional;
+
+import static com.peoplein.moiming.domain.session.QMoimSession.*;
+
+@Repository
+@RequiredArgsConstructor
+public class MoimSessionJpaRepository implements MoimSessionRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private final EntityManager em;
+
+    @Override
+    public Long save(MoimSession moimSession) {
+        em.persist(moimSession);
+        return moimSession.getId();
+    }
+
+    @Override
+    public Optional<MoimSession> findOptionalById(Long sessionId) {
+        return Optional.ofNullable(queryFactory.selectFrom(moimSession)
+                .where(moimSession.id.eq(sessionId))
+                .fetchOne());
+    }
+}

--- a/src/main/java/com/peoplein/moiming/repository/jpa/ScheduleJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/ScheduleJpaRepository.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
 import java.util.List;
+import java.util.Optional;
 
 import static com.peoplein.moiming.domain.QSchedule.*;
 import static com.peoplein.moiming.domain.QMoim.*;
@@ -29,6 +30,15 @@ public class ScheduleJpaRepository implements ScheduleRepository {
     @Override
     public Schedule findById(Long scheduleId) {
         return em.find(Schedule.class, scheduleId);
+    }
+
+    @Override
+    public Optional<Schedule> findOptionalById(Long scheduleId) {
+        return Optional.ofNullable(
+                queryFactory.selectFrom(schedule)
+                        .where(schedule.id.eq(scheduleId))
+                        .fetchOne()
+        );
     }
 
     @Override

--- a/src/main/java/com/peoplein/moiming/repository/jpa/SessionCategoryJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/SessionCategoryJpaRepository.java
@@ -1,0 +1,27 @@
+package com.peoplein.moiming.repository.jpa;
+
+import com.peoplein.moiming.domain.fixed.SessionCategory;
+import com.peoplein.moiming.repository.SessionCategoryRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static com.peoplein.moiming.domain.fixed.QSessionCategory.*;
+
+@Repository
+@RequiredArgsConstructor
+public class SessionCategoryJpaRepository implements SessionCategoryRepository {
+
+    private final EntityManager em;
+
+    private final JPAQueryFactory queryFactory;
+
+
+    @Override
+    public List<SessionCategory> findAllSessionCategories() {
+        return queryFactory.selectFrom(sessionCategory).fetch();
+    }
+}

--- a/src/main/java/com/peoplein/moiming/service/MoimSessionService.java
+++ b/src/main/java/com/peoplein/moiming/service/MoimSessionService.java
@@ -1,0 +1,97 @@
+package com.peoplein.moiming.service;
+
+import com.peoplein.moiming.domain.Member;
+import com.peoplein.moiming.domain.enums.MemberSessionState;
+import com.peoplein.moiming.domain.enums.SessionCategoryType;
+import com.peoplein.moiming.domain.session.MemberSessionCategoryLinker;
+import com.peoplein.moiming.domain.session.MemberSessionLinker;
+import com.peoplein.moiming.domain.session.MoimSession;
+import com.peoplein.moiming.domain.session.SessionCategoryItem;
+import com.peoplein.moiming.model.dto.domain.MoimSessionDto;
+import com.peoplein.moiming.model.dto.domain.SessionCategoryItemDto;
+import com.peoplein.moiming.model.dto.request.MoimSessionRequestDto;
+import com.peoplein.moiming.model.dto.response.MoimSessionResponseDto;
+import com.peoplein.moiming.service.input.MoimSessionServiceInput;
+import com.peoplein.moiming.service.shell.MoimSessionServiceShell;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MoimSessionService {
+
+    private final MoimSessionServiceShell moimSessionServiceShell;
+
+
+    public MoimSessionResponseDto createMoimSession(MoimSessionRequestDto moimSessionRequestDto, Member curMember) {
+
+
+        // moimSessionRequestDto 를 전달하여 Repository 단에서 통신 준비를 마치고, 준비된 애들을 가지고 와준다.
+        MoimSessionServiceInput entityInputs = moimSessionServiceShell.createInputForNewMoimSesion(moimSessionRequestDto);
+
+        /** 순서
+         *
+         * Moim Session 을 우선적으로 생성
+         * SessionCategoryItem 생성
+         * MemberSessionLinker 를 생성
+         * MemberSessionCategoryLinker 생성
+         *
+         */
+        MoimSessionDto moimSessionDto = moimSessionRequestDto.getMoimSessionDto();
+        MoimSession moimSession = MoimSession.createMoimSession(
+                moimSessionDto.getSessionName(), moimSessionDto.getSessionInfo()
+                , moimSessionDto.getTotalCost(), moimSessionDto.getTotalSenderCount(), curMember.getUid()
+                , entityInputs.getMoimOfNewMoimSession(), entityInputs.getScheduleOfNewMoimSession()
+        );
+
+        moimSessionRequestDto.getSessionCategoryDetailsDtos().forEach(categoryDetails -> {
+                    SessionCategoryType sessionCategoryType = categoryDetails.getSessionCategoryType();
+
+                    int costCnt = 0;
+
+                    for (SessionCategoryItemDto item : categoryDetails.getSessionCategoryItems()) {
+                        // 전송하는 기본 Data Set 지정 필요 > 그 항목으로 들어올 경우, DEFAUL 로 저장됨
+                        String itemName = item.getItemName();
+                        if (itemName.equals("기본") || itemName.equals("")) {
+                            itemName = SessionCategoryItem.DEFAULT_ITEM_NAME;
+                        }
+
+                        // CASCADE 로 moimSession 저장시 자동 저장
+                        SessionCategoryItem sessionCategoryItem = SessionCategoryItem.createSessionCategoryItem(
+                                itemName, item.getItemCost(), moimSession,
+                                entityInputs.getSessionCategoryByType(sessionCategoryType)
+                        );
+
+                        costCnt += item.getItemCost();
+                    }
+
+                    if (categoryDetails.getCategoryTotalCost() != costCnt) throw new RuntimeException("카테고리 정산이 일치하지 않습니다");
+                }
+        );
+
+        moimSessionRequestDto.getMemberSessionLinkerDtos().forEach(memberSessionLinkerDto -> {
+
+            // MoimSession push 시 cascade
+            MemberSessionLinker memberSessionLinker = MemberSessionLinker.createMemberSessionLinker(
+                    memberSessionLinkerDto.getSingleCost(), MemberSessionState.UNSENT
+                    , entityInputs.getMemberById(memberSessionLinkerDto.getMemberId())
+                    , moimSession
+            );
+
+            // MemberSessionLinker push 시 cascade
+            memberSessionLinkerDto.getSessionCategoryTypes().forEach(categoryType -> {
+                MemberSessionCategoryLinker memberSessionCategoryLinker = new MemberSessionCategoryLinker(
+                        memberSessionLinker, entityInputs.getSessionCategoryByType(categoryType)
+                );
+            });
+        });
+
+        // DB 에 푸시 후 RETURN Model 준비
+        moimSessionServiceShell.saveMoimSession(moimSession);
+
+        return moimSessionServiceShell.buildAllResponeModel(moimSession, curMember);
+    }
+}

--- a/src/main/java/com/peoplein/moiming/service/MoimSessionService.java
+++ b/src/main/java/com/peoplein/moiming/service/MoimSessionService.java
@@ -111,4 +111,11 @@ public class MoimSessionService {
         return moimSessionServiceShell.buildAllResponeModel(moimSession, curMember);
     }
 
+    public void updateMoimSession(MoimSessionRequestDto moimSessionRequestDto, Member curMember) {
+
+        // Long sessionId 에 val 이 하나 건너와야 한다
+
+
+    }
+
 }

--- a/src/main/java/com/peoplein/moiming/service/MoimSessionService.java
+++ b/src/main/java/com/peoplein/moiming/service/MoimSessionService.java
@@ -17,6 +17,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @Transactional
@@ -28,18 +30,9 @@ public class MoimSessionService {
 
     public MoimSessionResponseDto createMoimSession(MoimSessionRequestDto moimSessionRequestDto, Member curMember) {
 
-
         // moimSessionRequestDto 를 전달하여 Repository 단에서 통신 준비를 마치고, 준비된 애들을 가지고 와준다.
         MoimSessionServiceInput entityInputs = moimSessionServiceShell.createInputForNewMoimSesion(moimSessionRequestDto);
 
-        /** 순서
-         *
-         * Moim Session 을 우선적으로 생성
-         * SessionCategoryItem 생성
-         * MemberSessionLinker 를 생성
-         * MemberSessionCategoryLinker 생성
-         *
-         */
         MoimSessionDto moimSessionDto = moimSessionRequestDto.getMoimSessionDto();
         MoimSession moimSession = MoimSession.createMoimSession(
                 moimSessionDto.getSessionName(), moimSessionDto.getSessionInfo()
@@ -94,4 +87,28 @@ public class MoimSessionService {
 
         return moimSessionServiceShell.buildAllResponeModel(moimSession, curMember);
     }
+
+    public List<MoimSessionDto> getAllMoimSessions(Long moimId, Member curMember) {
+
+        /*
+         1. MoimId 를 통해 모임을 조회
+         2. MoimSession 을 조회할 수 있도록 한다
+         3. MoimSession 들의 기본 정보 형성 및 전달을 위해선?
+         */
+        List<MoimSession> moimSessions = moimSessionServiceShell.getAllMoimSessions(moimId);
+        List<MoimSessionDto> moimSessionDtos = new ArrayList<>();
+
+        moimSessions.forEach(moimSession -> {
+            moimSessionDtos.add(new MoimSessionDto(moimSession));
+        });
+
+        return moimSessionDtos;
+    }
+
+    public MoimSessionResponseDto getMoimSession(Long moimSessionId, Member curMember) {
+        // MoimSession 을 가지고 와서 ResponseModel 을 만든다
+        MoimSession moimSession = moimSessionServiceShell.getMoimSession(moimSessionId);
+        return moimSessionServiceShell.buildAllResponeModel(moimSession, curMember);
+    }
+
 }

--- a/src/main/java/com/peoplein/moiming/service/input/MoimSessionServiceInput.java
+++ b/src/main/java/com/peoplein/moiming/service/input/MoimSessionServiceInput.java
@@ -1,0 +1,44 @@
+package com.peoplein.moiming.service.input;
+
+import com.peoplein.moiming.domain.Member;
+import com.peoplein.moiming.domain.Moim;
+import com.peoplein.moiming.domain.Schedule;
+import com.peoplein.moiming.domain.enums.SessionCategoryType;
+import com.peoplein.moiming.domain.fixed.SessionCategory;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Getter
+@Builder
+public class MoimSessionServiceInput {
+
+
+    private Moim moimOfNewMoimSession;
+
+    private Schedule scheduleOfNewMoimSession;
+
+    // 모든 카테고리를 그냥 한번에 준비하자. 얼마 되지도 않고, 로직 복잡하게 가져가지 말고
+    private List<SessionCategory> allSessionCategories = new ArrayList<>();
+
+    // 전달받은 참여 MemberId 들을 통해 참여 Member 들을 가져온다
+    private List<Member> allSessionMembers = new ArrayList<>();
+
+    public SessionCategory getSessionCategoryByType(SessionCategoryType sessionCategoryType) {
+        return allSessionCategories.stream().filter(sessionCategory -> sessionCategory.getCategoryType().equals(sessionCategoryType)).findAny()
+                .orElseThrow(() -> new RuntimeException("SessionCategoryList 를 불러오는데 오류가 발생했습니다"));
+    }
+
+    public Member getMemberById(Long memberId) {
+        return allSessionMembers.stream().filter(member -> member.getId().equals(memberId)).findAny()
+                .orElseThrow(() -> new RuntimeException("해당 id: " + memberId + "의 멤버를 찾을 수 없습니다"));
+    }
+
+}
+
+/*
+  Service 계층에서 활용할 Entity 들을 준비시켜준다
+ */

--- a/src/main/java/com/peoplein/moiming/service/shell/MoimSessionServiceShell.java
+++ b/src/main/java/com/peoplein/moiming/service/shell/MoimSessionServiceShell.java
@@ -1,0 +1,144 @@
+package com.peoplein.moiming.service.shell;
+
+import com.peoplein.moiming.domain.Member;
+import com.peoplein.moiming.domain.MemberMoimLinker;
+import com.peoplein.moiming.domain.Moim;
+import com.peoplein.moiming.domain.Schedule;
+import com.peoplein.moiming.domain.enums.SessionCategoryType;
+import com.peoplein.moiming.domain.fixed.SessionCategory;
+import com.peoplein.moiming.domain.session.MoimSession;
+import com.peoplein.moiming.domain.session.SessionCategoryItem;
+import com.peoplein.moiming.model.dto.SessionCategoryDetailsDto;
+import com.peoplein.moiming.model.dto.domain.*;
+import com.peoplein.moiming.model.dto.request.MoimSessionRequestDto;
+import com.peoplein.moiming.model.dto.response.MoimSessionResponseDto;
+import com.peoplein.moiming.repository.*;
+import com.peoplein.moiming.service.input.MoimSessionServiceInput;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class MoimSessionServiceShell {
+
+    private final MemberRepository memberRepository;
+    private final MemberMoimLinkerRepository memberMoimLinkerRepository;
+    private final MoimRepository moimRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final MoimSessionRepository moimSessionRepository;
+    private final SessionCategoryRepository sessionCategoryRepository;
+
+    public MoimSessionServiceInput createInputForNewMoimSesion(MoimSessionRequestDto moimSessionRequestDto) {
+
+        Moim moim = moimRepository.findOptionalById(moimSessionRequestDto.getMoimSessionDto().getMoimId()).orElseThrow(() -> new RuntimeException("해당 모임이 존재하지 않습니다"));
+        Schedule schedule = null;
+
+        if (!Objects.isNull(moimSessionRequestDto.getMoimSessionDto().getScheduleId())) {
+            schedule = scheduleRepository.findOptionalById(moimSessionRequestDto.getMoimSessionDto().getScheduleId()).orElseThrow(() -> new RuntimeException("해당 일정이 존재하지 않습니다"));
+        }
+
+        List<SessionCategory> sessionCategories = sessionCategoryRepository.findAllSessionCategories();
+
+        List<Long> memberIds = moimSessionRequestDto.getMemberSessionLinkerDtos().stream().map(MemberSessionLinkerDto::getMemberId).collect(Collectors.toList());
+        List<Member> sessionMembers = memberRepository.findMembersByIds(memberIds);
+
+        return MoimSessionServiceInput.builder()
+                .moimOfNewMoimSession(moim)
+                .scheduleOfNewMoimSession(schedule)
+                .allSessionCategories(sessionCategories)
+                .allSessionMembers(sessionMembers)
+                .build();
+    }
+
+    public Long saveMoimSession(MoimSession moimSession) {
+        return moimSessionRepository.save(moimSession);
+    }
+
+    public void buildDefaultResponseModel(MoimSession moimSession) {
+
+    }
+
+    public MoimSessionResponseDto buildAllResponeModel(MoimSession moimSession
+            , Member curMember) {
+
+        // MoimSession 정보를 기준으로 다 만들어낸다
+        MoimSessionDto moimSessionDto = new MoimSessionDto(moimSession);
+
+        // MoimSession 내 Schedule 정보로 ScheduleDto 를 만들어준다
+        ScheduleDto scheduleDto = null;
+        if (moimSession.getSchedule() != null) {
+            scheduleDto = new ScheduleDto(moimSession.getSchedule());
+        }
+
+        Map<SessionCategoryType, List<SessionCategoryItem>> tempMap = new HashMap<>();
+
+        // 돌면서 SessionCategoryType 인 애들에 맞춰서 분류한다
+        moimSession.getSessionCategoryItems().forEach(sessionCategoryItem -> {
+
+            if (tempMap.containsKey(sessionCategoryItem.getSessionCategory().getCategoryType())) {
+                tempMap.get(sessionCategoryItem.getSessionCategory().getCategoryType()).add(sessionCategoryItem);
+            } else {
+                List<SessionCategoryItem> categoryItemList = new ArrayList();
+                categoryItemList.add(sessionCategoryItem);
+                tempMap.put(sessionCategoryItem.getSessionCategory().getCategoryType(), categoryItemList);
+            }
+        });
+
+        List<SessionCategoryDetailsDto> sessionCategoryDetailsDtos = new ArrayList<>();
+
+        // 위에서 넣을 수 있긴 한데 그냥 깔끔하게 하기 위해서 밖에서 한번 더 돌면서 세팅
+        for (SessionCategoryType categoryType : tempMap.keySet()) {
+
+            List<SessionCategoryItemDto> sessionCategoryItems = new ArrayList<>();
+
+            tempMap.get(categoryType).forEach(sessionCategoryItem -> {
+                sessionCategoryItems.add(new SessionCategoryItemDto(sessionCategoryItem));
+            });
+
+            SessionCategoryDetailsDto categoryDetailsDto = new SessionCategoryDetailsDto(
+                    categoryType, sessionCategoryItems
+            );
+            sessionCategoryDetailsDtos.add(categoryDetailsDto);
+        }
+
+        ////////////// 회원들 Data 연결
+
+        // MemberMoimLinker 들도 Batch 로 불러오고, 아래에서 매핑해서 가져가주기 위해서 Id 및 List 준비
+        List<Long> memberIds = moimSession.getMemberSessionLinkers().stream()
+                .map(memberSessionLinker -> memberSessionLinker.getMember().getId()).collect(Collectors.toList());
+
+        List<MemberMoimLinker> sessionMembersMoimLinkers = memberMoimLinkerRepository.findByMoimIdAndMemberIds(moimSession.getMoim().getId(), memberIds);
+
+
+        List<MemberSessionLinkerDto> memberSessionLinkerDtos = new ArrayList<>();
+
+        moimSession.getMemberSessionLinkers().forEach(memberSessionLinker -> {
+
+            // TODO: 각 정산활동의 참여 멤버들을 확인한다
+            //       참여 멤버들을 조회 & 확인 후, Moim 에서의 관계 확인 후 보내준다
+
+            // 이미 Member, MemberInfo 까지 영컨에 올라온 상태
+            MemberMoimLinker thisMemberMoimLinker = sessionMembersMoimLinkers.stream().filter(
+                    memberMoimLinker -> memberMoimLinker.getMember().getId().equals(memberSessionLinker.getMember().getId())
+            ).findAny().orElseThrow(() -> new RuntimeException("가지고 온 MoimMember 정보 중 " + memberSessionLinker.getMember().getUid() + "의 정보를 찾을 수 없습니다"));
+
+            MoimMemberInfoDto moimMemberInfoDto = MoimMemberInfoDto.createMemberInfoDto(thisMemberMoimLinker);
+
+            MemberSessionLinkerDto memberSessionLinkerDto = new MemberSessionLinkerDto(
+                    memberSessionLinker.getMember().getId(), memberSessionLinker.getSingleCost()
+                    , memberSessionLinker.getMemberSessionCategoryTypes()
+                    , moimMemberInfoDto
+            );
+            memberSessionLinkerDtos.add(memberSessionLinkerDto);
+        });
+
+
+        return new MoimSessionResponseDto(moimSessionDto, scheduleDto
+                , sessionCategoryDetailsDtos
+                , memberSessionLinkerDtos);
+    }
+
+}

--- a/src/main/java/com/peoplein/moiming/service/shell/MoimSessionServiceShell.java
+++ b/src/main/java/com/peoplein/moiming/service/shell/MoimSessionServiceShell.java
@@ -57,8 +57,13 @@ public class MoimSessionServiceShell {
         return moimSessionRepository.save(moimSession);
     }
 
-    public void buildDefaultResponseModel(MoimSession moimSession) {
+    public List<MoimSession> getAllMoimSessions(Long moimId) {
+        return moimSessionRepository.findAllByMoimId(moimId);
+    }
 
+    public MoimSession getMoimSession(Long moimSessionId) {
+//        moimSessionId 로 우선 조회하되,
+        return moimSessionRepository.findOptionalById(moimSessionId).orElseThrow(() -> new RuntimeException("해당 MoimSession 을 찾을 수 없습니다"));
     }
 
     public MoimSessionResponseDto buildAllResponeModel(MoimSession moimSession
@@ -78,13 +83,13 @@ public class MoimSessionServiceShell {
         // 돌면서 SessionCategoryType 인 애들에 맞춰서 분류한다
         moimSession.getSessionCategoryItems().forEach(sessionCategoryItem -> {
 
-            if (tempMap.containsKey(sessionCategoryItem.getSessionCategory().getCategoryType())) {
-                tempMap.get(sessionCategoryItem.getSessionCategory().getCategoryType()).add(sessionCategoryItem);
-            } else {
-                List<SessionCategoryItem> categoryItemList = new ArrayList();
-                categoryItemList.add(sessionCategoryItem);
-                tempMap.put(sessionCategoryItem.getSessionCategory().getCategoryType(), categoryItemList);
+            if (!tempMap.containsKey(sessionCategoryItem.getSessionCategory().getCategoryType())) {
+                tempMap.put(sessionCategoryItem.getSessionCategory().getCategoryType(), new ArrayList<>());
             }
+
+            List<SessionCategoryItem> categoryItemList = tempMap.get(sessionCategoryItem.getSessionCategory().getCategoryType());
+            categoryItemList.add(sessionCategoryItem);
+            tempMap.put(sessionCategoryItem.getSessionCategory().getCategoryType(), categoryItemList);
         });
 
         List<SessionCategoryDetailsDto> sessionCategoryDetailsDtos = new ArrayList<>();
@@ -116,9 +121,6 @@ public class MoimSessionServiceShell {
         List<MemberSessionLinkerDto> memberSessionLinkerDtos = new ArrayList<>();
 
         moimSession.getMemberSessionLinkers().forEach(memberSessionLinker -> {
-
-            // TODO: 각 정산활동의 참여 멤버들을 확인한다
-            //       참여 멤버들을 조회 & 확인 후, Moim 에서의 관계 확인 후 보내준다
 
             // 이미 Member, MemberInfo 까지 영컨에 올라온 상태
             MemberMoimLinker thisMemberMoimLinker = sessionMembersMoimLinkers.stream().filter(

--- a/src/main/resources/session-create-request-body.json
+++ b/src/main/resources/session-create-request-body.json
@@ -1,0 +1,76 @@
+{
+  "moimSessionDto":{
+    "moimId":15,
+    "scheduleId":26,
+    "sessionName":"3월 회식 정산",
+    "sessionInfo":"1,2차 나눠서 정산합니다",
+    "totalCost":30000,
+    "totalSenderCount":10
+  },
+
+  "sessionCategoryDetailsDtos":[
+    {
+      "sessionCategoryType": "ACTIVITY",
+      "categoryTotalCost": 10000,
+      "sessionCategoryItems": [
+        {
+          "itemName":"룸대여",
+          "itemCost":"5000"
+        },
+        {
+          "itemName": "",
+          "itemCost": "5000"
+        }
+      ]
+    },
+    {
+      "sessionCategoryType": "FOOD",
+      "categoryTotalCost": 10000,
+      "sessionCategoryItems": [
+        {
+          "itemName":"1차치킨",
+          "itemCost":"7000"
+        },
+        {
+          "itemName": "",
+          "itemCost": "3000"
+        }
+      ]
+    },
+    {
+      "sessionCategoryType": "ALCOHOL",
+      "categoryTotalCost": 10000,
+      "sessionCategoryItems": [
+        {
+          "itemName":"소주값",
+          "itemCost":"10000"
+        }
+      ]
+    }
+  ],
+  "memberSessionLinkerDtos":
+  [
+    {
+      "memberId":1,
+      "singleCost": 10000,
+      "sessionCategoryTypes": [
+        "ACTIVITY", "FOOD"
+      ]
+    },
+    {
+      "memberId":4,
+      "singleCost": 10000,
+      "sessionCategoryTypes": [
+        "ACTIVITY", "FOOD", "ALCOHOL"
+      ]
+    },
+    {
+      "memberId":7,
+      "singleCost": 10000,
+      "sessionCategoryTypes": [
+        "FOOD", "ALCOHOL"
+      ]
+    }
+
+  ]
+}


### PR DESCRIPTION
### 1. 정산활동 도메인 추가

1. MoimSession, MemberSessionLinker, MemberSessionCategoryLinker, SessionCategoryItem, SessionCategory Entity 들 추가 하였습니다 (연관관계 ERD Cloud 참조)

2. 탐색이 많이 이루어질 것 같은 연관관계 들에 대해서는 일대다(OneToMay, 1:N) 또한 매핑해 두었습니다.
>MoimSession --> MemberSessionLinker, SessionCategoryItem  
>MemberSessionLinker --> MemberSessionCategoryLinker (이 관계에서 바로 SessionCategory 만 들고올 수 있는 관계면 좋은데, 다대다 관계도 결국 일대다, 다대일 관계로 풀어질테니 그냥 MemberSessionCategoryLinker 란 객체를 하나 더 둘 수 밖에 없었습니다)



### 2. 도메인, Request / Response Dto  추가 
1. MoimSessionDto / SessionCategoryItemDto / MemberSessionLinkerDto (CategoryType 에 대해서는 String 값만 오고 가고 앱 단에서 해당 타입을 enum 으로 저장해서 알맞은 SessionCategoryType Entity 를 찾아와 DB에 저장시키는 구조로 개발)

2. MoimSessionRequestDto , MoimSessionResponseDto
> MoimSession 에 대한 추가 / 변경 요청을 할 시 데이터를 담아서 보낼 수 있는 DTO 입니다. 
> MoimSessionRequestDto 와 유사하지만, 필요시 Schedule 에 대한 Dto  도 전달해 줄 수 있도록 추가된 응답 DTO 입니다.

3. SessionCategoryDetailsDto
> 정산활동은 기본적으로  [정산활동 Category] 내부에 여러 [정산활동 Item] 들이 있는 관계입니다. Category 는 Fixed DB 이며, Item 은 유저의 입력에 따라 쌓이는 DB 입니다. 
> 특정 정산활동에 기본적으로 5가지 Category 가 있고, 유저가 만든 정산활동 항목들은 각 Category 밑으로 들어가게 됩니다. 이 때 각 Category  하위 Item 들을 합쳐서 한 객체로 송/수신 하기 위해, 해당 Dto 를 만들었습니다.



### 3. MoimSession Create Request

1.  Service 단 동작 구조 
>MoimSessionController > MoimSessionService 로 이동을 하고, Service 단에서는 Service Class 내에서 핵심 로직을 수행하고, ServiceShell Class 에서 Repository 및 Reponse Build 업무를 수행합니다 (상혁님과 모델링과 동일). 이 때, RequestDto 로 들어오는 모든 데이터를 다 Input 클래스로 송/수신 하지 않고, 핵심 로직을 Service Class 내에서 진행되기 때문에 그냥 Params 로 받아온 RequestDto 에서 직접 뽑아서 데이터를 사용합니다. DTO 값들에 대한 Validation 은 해당 토픽으로 Refactor 시 나중에 일괄적으로 Controller 단에서 체킹될 수 있도록 하면 될 것 같습니다 

2. 핵심 로직 동작 구조 
> SessionCategory 라는 데이터가 조금 이상하게(?) 연관되어 있는 탓에 (그래도 제가 생각할 수 있는 베스트 모델이긴 했습니다..) 저장 및 응답 모델 생성 방식이 조금 복잡합니다. 이해가 어려운 부분 있을시 빠르게 답변드리겠습니다.
