### PR TITLE
Ash search

### DIFF
--- a/src/main/java/com/peoplein/moiming/controller/dto/SearchConditionDto.java
+++ b/src/main/java/com/peoplein/moiming/controller/dto/SearchConditionDto.java
@@ -1,0 +1,13 @@
+package com.peoplein.moiming.controller.dto;
+
+import com.peoplein.moiming.domain.embeddable.Area;
+import com.peoplein.moiming.domain.fixed.Category;
+
+public class SearchConditionDto {
+
+
+    private String searchKeyword;
+    private Area area;
+    private Category category;
+
+}

--- a/src/main/java/com/peoplein/moiming/repository/MoimRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/MoimRepository.java
@@ -1,6 +1,8 @@
 package com.peoplein.moiming.repository;
 
 import com.peoplein.moiming.domain.Moim;
+import com.peoplein.moiming.domain.embeddable.Area;
+import com.peoplein.moiming.domain.fixed.Category;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,4 +17,6 @@ public interface MoimRepository {
     Moim findWithRulesById(Long moimId);
 
     void remove(Moim moim);
+
+    List<Moim> findMoimBySearchCondition(List<String> keywordList, Area area, Category category);
 }

--- a/src/main/java/com/peoplein/moiming/repository/jpa/MoimJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/MoimJpaRepository.java
@@ -2,16 +2,29 @@ package com.peoplein.moiming.repository.jpa;
 
 import com.peoplein.moiming.domain.Moim;
 import com.peoplein.moiming.domain.QMoim;
+import com.peoplein.moiming.domain.QMoimCategoryLinker;
+import com.peoplein.moiming.domain.embeddable.Area;
+import com.peoplein.moiming.domain.embeddable.QArea;
+import com.peoplein.moiming.domain.fixed.Category;
 import com.peoplein.moiming.repository.MoimRepository;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.peoplein.moiming.domain.QMoim.*;
+import static com.peoplein.moiming.domain.QMoimCategoryLinker.*;
+import static com.peoplein.moiming.domain.embeddable.QArea.*;
+import static com.peoplein.moiming.domain.embeddable.QArea.area;
 import static com.peoplein.moiming.domain.rules.QMoimRule.*;
 
 @Repository
@@ -62,5 +75,31 @@ public class MoimJpaRepository implements MoimRepository {
     public void
     remove(Moim moim) {
         em.remove(moim);
+    }
+
+    @Override
+    public List<Moim> findMoimBySearchCondition(List<String> keywordList, Area area, Category category) {
+        JPAQuery<Moim> query = queryFactory.selectFrom(moim)
+                .where(areaEq(area), keywordEq(keywordList));
+        addJoinQuery(query, category);
+        return query.fetch();
+    }
+
+    private void addJoinQuery(JPAQuery<Moim> query, Category category) {
+        if (category == null)
+            return;
+
+        query.leftJoin(moimCategoryLinker)
+                .on(moimCategoryLinker.moim.id.eq(moim.id).and(moimCategoryLinker.category.id.eq(category.getId())));
+    }
+
+    private Predicate keywordEq(List<String> keywordsList) {
+        BooleanBuilder booleanBuilder = new BooleanBuilder();
+        keywordsList.forEach(keyword -> booleanBuilder.or(moim.moimName.like("%" + keyword + "%")));
+        return booleanBuilder.getValue();
+    }
+
+    private BooleanExpression areaEq(Area area) {
+        return area != null ? moim.moimArea.eq(area) : null;
     }
 }

--- a/src/main/java/com/peoplein/moiming/service/SearchService.java
+++ b/src/main/java/com/peoplein/moiming/service/SearchService.java
@@ -5,6 +5,7 @@ import com.peoplein.moiming.domain.embeddable.Area;
 import com.peoplein.moiming.domain.fixed.Category;
 import com.peoplein.moiming.repository.MoimRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.util.Arrays;
 import java.util.List;
@@ -34,5 +35,10 @@ public class SearchService {
         if (matcher.find()) {
             throw new IllegalArgumentException("자음 불가능");
         }
+
+        if (!StringUtils.hasText(keywords)) {
+            throw new IllegalArgumentException("공백 불가능");
+        }
+
     }
 }

--- a/src/main/java/com/peoplein/moiming/service/SearchService.java
+++ b/src/main/java/com/peoplein/moiming/service/SearchService.java
@@ -1,0 +1,38 @@
+package com.peoplein.moiming.service;
+
+import com.peoplein.moiming.domain.Moim;
+import com.peoplein.moiming.domain.embeddable.Area;
+import com.peoplein.moiming.domain.fixed.Category;
+import com.peoplein.moiming.repository.MoimRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+@Service
+public class SearchService {
+
+
+    private final MoimRepository moimRepository;
+    private Pattern restrictCondition = Pattern.compile("[ㄱ-ㅎ]+");
+
+    public SearchService(MoimRepository moimRepository) {
+        this.moimRepository = moimRepository;
+    }
+
+    public List<Moim> searchMoim(String keywords, Area area, Category category) {
+        shouldKeywordValid(keywords);
+        List<String> keywordList = Arrays.stream(keywords.split(" ")).collect(Collectors.toList());
+        return moimRepository.findMoimBySearchCondition(keywordList, area, category);
+    }
+
+    private void shouldKeywordValid(String keywords) {
+        Matcher matcher = restrictCondition.matcher(keywords);
+        if (matcher.find()) {
+            throw new IllegalArgumentException("자음 불가능");
+        }
+    }
+}

--- a/src/test/java/com/peoplein/moiming/TestUtils.java
+++ b/src/test/java/com/peoplein/moiming/TestUtils.java
@@ -242,4 +242,12 @@ public class TestUtils {
         jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
     }
 
+
+    public static Area createAreaForTest() {
+        return new Area(TestUtils.areaState, TestUtils.areaCity);
+    }
+
+    public static Category createCategoryForTest() {
+        return new Category();
+    }
 }

--- a/src/test/java/com/peoplein/moiming/TestUtils.java
+++ b/src/test/java/com/peoplein/moiming/TestUtils.java
@@ -133,6 +133,10 @@ public class TestUtils {
         return Moim.createMoim(moimName, moimInfo, moimPfImg, new Area(areaState, areaCity), createdUid);
     }
 
+    public static Moim createOtherMoimOnly(String moimName, Area area) {
+        return Moim.createMoim(moimName, "other" + moimInfo, "other" + moimPfImg, area, createdUid);
+    }
+
     public static MoimPost initMoimPost(Moim moim, Member member) {
         return MoimPost.createMoimPost(postTitle, postContent, moimPostCategory, isNotice, hasFiles, moim, member);
     }
@@ -166,7 +170,7 @@ public class TestUtils {
 
 
     public static List<CategoryName> initCategoryName() {
-        return List.of(CategoryName.ALCOHOL);
+        return List.of(CategoryName.ALCOHOL, CategoryName.CODING);
     }
 
 
@@ -181,6 +185,18 @@ public class TestUtils {
         newCategory.setCategoryName(categoryNames.get(0));
         return List.of(newCategory);
     }
+
+    public static List<Category> createMoimCategoriesWithTwo() {
+        List<CategoryName> categoryNames = TestUtils.initCategoryName();
+        Category newCategory1 = new Category();
+        newCategory1.setCategoryName(categoryNames.get(0));
+
+        Category newCategory2 = new Category();
+        newCategory2.setCategoryName(categoryNames.get(1));
+
+        return List.of(newCategory1, newCategory2);
+    }
+
 
     public static void initDatabase(InitDatabaseQuery initDatabase) {
         initDatabase.initUserRole();

--- a/src/test/java/com/peoplein/moiming/service/SearchServiceTest.java
+++ b/src/test/java/com/peoplein/moiming/service/SearchServiceTest.java
@@ -6,6 +6,7 @@ import com.peoplein.moiming.domain.fixed.Category;
 import com.peoplein.moiming.repository.MoimRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,7 +17,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 //@SpringBootTest
 class SearchServiceTest {
-
 
     SearchService searchService;
 
@@ -34,6 +34,7 @@ class SearchServiceTest {
 
 
     @Test
+    @DisplayName("searchService.searchMoimTest")
     void 자음아니면_에러발생하지_않음() {
         // Given:
         String keywords = "가나다";
@@ -44,6 +45,7 @@ class SearchServiceTest {
     }
 
     @Test
+    @DisplayName("searchService.searchMoimTest")
     void 자음_에러_발생1() {
         // Given:
         String keywords = "아아ㄱㄴㄷ아아";
@@ -54,6 +56,7 @@ class SearchServiceTest {
     }
 
     @Test
+    @DisplayName("searchService.searchMoimTest")
     void 자음_에러_발생2() {
         // Given:
         String keywords = "아아아아 아아ㄱ아아";
@@ -64,6 +67,7 @@ class SearchServiceTest {
     }
 
     @Test
+    @DisplayName("searchService.searchMoimTest")
     void 자음_에러_발생3() {
         // Given:
         String keywords = "ㄱ";
@@ -74,6 +78,7 @@ class SearchServiceTest {
     }
 
     @Test
+    @DisplayName("searchService.searchMoimTest")
     void 자음_에러_발생4() {
         // Given:
         String keywords = "ㄱ ㄴ 가나다라";
@@ -84,6 +89,7 @@ class SearchServiceTest {
     }
 
     @Test
+    @DisplayName("searchService.searchMoimTest")
     void 자음_에러_발생5() {
         // Given:
         String keywords = "가나다라 ㄱ ㄴ 가나다라";
@@ -94,6 +100,7 @@ class SearchServiceTest {
     }
 
     @Test
+    @DisplayName("searchService.searchMoimTest")
     void 자음_에러_발생6() {
         // Given:
         String keywords = "ㄱ가나다라 가나다라";
@@ -104,12 +111,27 @@ class SearchServiceTest {
     }
 
     @Test
+    @DisplayName("searchService.searchMoimTest")
     void 자음_에러_발생7() {
         // Given:
         String keywords = "가나다라ㄱ 가나다라";
 
         // When + THEN:
         assertThatThrownBy(() -> searchService.searchMoim(keywords, area, category))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("searchService.searchMoimTest")
+    void 공백_에러_발생7() {
+        // Given:
+        String keywords1 = "";
+        String keywords2 = "";
+
+        // When + THEN:
+        assertThatThrownBy(() -> searchService.searchMoim(keywords1, area, category))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> searchService.searchMoim(keywords2, area, category))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/com/peoplein/moiming/service/SearchServiceTest.java
+++ b/src/test/java/com/peoplein/moiming/service/SearchServiceTest.java
@@ -1,0 +1,115 @@
+package com.peoplein.moiming.service;
+
+import com.peoplein.moiming.TestUtils;
+import com.peoplein.moiming.domain.embeddable.Area;
+import com.peoplein.moiming.domain.fixed.Category;
+import com.peoplein.moiming.repository.MoimRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+//@SpringBootTest
+class SearchServiceTest {
+
+
+    SearchService searchService;
+
+    Area area;
+    Category category;
+
+    @BeforeEach
+    void setUp() {
+        MoimRepository moimRepository = Mockito.mock(MoimRepository.class);
+        searchService = new SearchService(moimRepository);
+
+        area = TestUtils.createAreaForTest();
+        category = TestUtils.createCategoryForTest();
+    }
+
+
+    @Test
+    void 자음아니면_에러발생하지_않음() {
+        // Given:
+        String keywords = "가나다";
+
+        // When + THEN:
+        assertThatCode(() -> searchService.searchMoim(keywords, area, category))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void 자음_에러_발생1() {
+        // Given:
+        String keywords = "아아ㄱㄴㄷ아아";
+
+        // When + THEN:
+        assertThatThrownBy(() -> searchService.searchMoim(keywords, area, category))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 자음_에러_발생2() {
+        // Given:
+        String keywords = "아아아아 아아ㄱ아아";
+
+        // When + THEN:
+        assertThatThrownBy(() -> searchService.searchMoim(keywords, area, category))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 자음_에러_발생3() {
+        // Given:
+        String keywords = "ㄱ";
+
+        // When + THEN:
+        assertThatThrownBy(() -> searchService.searchMoim(keywords, area, category))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 자음_에러_발생4() {
+        // Given:
+        String keywords = "ㄱ ㄴ 가나다라";
+
+        // When + THEN:
+        assertThatThrownBy(() -> searchService.searchMoim(keywords, area, category))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 자음_에러_발생5() {
+        // Given:
+        String keywords = "가나다라 ㄱ ㄴ 가나다라";
+
+        // When + THEN:
+        assertThatThrownBy(() -> searchService.searchMoim(keywords, area, category))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 자음_에러_발생6() {
+        // Given:
+        String keywords = "ㄱ가나다라 가나다라";
+
+        // When + THEN:
+        assertThatThrownBy(() -> searchService.searchMoim(keywords, area, category))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void 자음_에러_발생7() {
+        // Given:
+        String keywords = "가나다라ㄱ 가나다라";
+
+        // When + THEN:
+        assertThatThrownBy(() -> searchService.searchMoim(keywords, area, category))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
### Moim 검색 조건 구현
- 아래 스크린샷에 있는 기능을 구현했습니다.
- 검색 키워드는 "가나다 라마바 사아" 같은 형태로 받는다고 가정해서 String keyword로 받고, " "로 split해서 사용하도록 했습니다.
- 제약 조건 (자음 검색 안됨)은 정규표현식으로 구현했습니다.
- 검색은 쿼리로 작성했습니다. join 쿼리를 써야했었는데, 이건 Moim 엔티티가 MoimCategoryLinker를 가지고 있지 않아서 이렇게 해야했습니다.
- 필요한 테스트 코드들을 작성했습니다.
- 최종적으로는 조건에 맞는 Entity 리스트를 Controller에 전달하는 기능입니다. Controller는 엔티티들을 받아서, Dto로 포장해서 Response를 해야하는데 이건 나중에 정해지면 구현하면 좋을 것 같습니다. 
![image](https://user-images.githubusercontent.com/126734704/230121643-1e07b53b-b9da-4db2-ba1c-6f01a696df8c.png)
