### PR TITLE
FCM 초기 SU 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ dependencies {
 
 	// FCM 환경
 	implementation 'com.google.firebase:firebase-admin:9.1.1'
+	implementation 'com.google.firebase:firebase-messaging'
 
 
 	// https://mvnrepository.com/artifact/org.mockito/mockito-core

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,16 @@
 buildscript {
-	ext {
-		queryDslVersion = "5.0.0"
-	}
+    ext {
+        queryDslVersion = "5.0.0"
+    }
 }
 
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '2.7.6'
-	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id 'java'
+    id 'org.springframework.boot' version '2.7.6'
+    id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 
-	// QueryDsl 추가
-	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
+    // QueryDsl 추가
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'com.peoplein'
@@ -18,80 +18,82 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	testImplementation 'junit:junit:4.13.1'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'junit:junit:4.13.1'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 
-	// JWT 토큰 라이브러리
-	implementation 'com.auth0:java-jwt:4.2.1'
+    // JWT 토큰 라이브러리
+    implementation 'com.auth0:java-jwt:4.2.1'
 
-	// Swagger API Lib
-	implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
+    // Swagger API Lib
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.9'
 
-	// QueryDsl 추가
-	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
-	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
+    // QueryDsl 추가
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
 
-	// Java 8 직렬화 해결
-	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
-	implementation 'com.fasterxml.jackson.core:jackson-databind'
+    // Java 8 직렬화 해결
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
 
-	// Test 환경
+    // Test 환경
 //	runtimeOnly 'com.h2database:h2'
 
-	// FCM 환경
-	implementation 'com.google.firebase:firebase-admin:9.1.1'
-	implementation 'com.google.firebase:firebase-messaging'
+    // FCM 환경
+    implementation 'com.google.firebase:firebase-admin:9.1.1'
+    implementation 'com.google.firebase:firebase-messaging'
 
+    // Http 요청 Library (OkHttp)
+    implementation 'com.squareup.okhttp3:okhttp:4.9.3'
 
-	// https://mvnrepository.com/artifact/org.mockito/mockito-core
-	testImplementation 'org.mockito:mockito-core:4.10.0'
-	testImplementation 'org.mockito:mockito-junit-jupiter:4.10.0'
+    // https://mvnrepository.com/artifact/org.mockito/mockito-core
+    testImplementation 'org.mockito:mockito-core:4.10.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:4.10.0'
 
-	// https://mvnrepository.com/artifact/org.testcontainers/junit-jupiter
-	testImplementation 'org.testcontainers:junit-jupiter:1.17.6'
-	testImplementation 'org.testcontainers:mysql:1.17.6'
+    // https://mvnrepository.com/artifact/org.testcontainers/junit-jupiter
+    testImplementation 'org.testcontainers:junit-jupiter:1.17.6'
+    testImplementation 'org.testcontainers:mysql:1.17.6'
 
-	testRuntimeOnly 'com.mysql:mysql-connector-j'
+    testRuntimeOnly 'com.mysql:mysql-connector-j'
 //	untimeOnly 'com.mysql:mysql-connector-j'
 
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
 
 // QueryDsl 추가
 def querydslDir = "$buildDir/generated/querydsl"
 
 querydsl {
-	jpa = true
-	querydslSourcesDir = querydslDir
+    jpa = true
+    querydslSourcesDir = querydslDir
 }
 sourceSets {
-	main.java.srcDir querydslDir
+    main.java.srcDir querydslDir
 }
 configurations {
-	querydsl.extendsFrom compileClasspath
+    querydsl.extendsFrom compileClasspath
 }
 compileQuerydsl {
-	options.annotationProcessorPath = configurations.querydsl
+    options.annotationProcessorPath = configurations.querydsl
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ configurations {
 
 repositories {
     mavenCentral()
+    google()
 }
 
 dependencies {
@@ -59,7 +60,7 @@ dependencies {
 
     // FCM 환경
     implementation 'com.google.firebase:firebase-admin:9.1.1'
-    implementation 'com.google.firebase:firebase-messaging'
+    implementation 'com.google.firebase:firebase-messaging:22.0.0'
 
     // Http 요청 Library (OkHttp)
     implementation 'com.squareup.okhttp3:okhttp:4.9.3'

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ dependencies {
 	// Test 환경
 //	runtimeOnly 'com.h2database:h2'
 
+	// FCM 환경
+	implementation 'com.google.firebase:firebase-admin:9.1.1'
+
 
 	// https://mvnrepository.com/artifact/org.mockito/mockito-core
 	testImplementation 'org.mockito:mockito-core:4.10.0'
@@ -68,6 +71,7 @@ dependencies {
 
 	testRuntimeOnly 'com.mysql:mysql-connector-j'
 //	untimeOnly 'com.mysql:mysql-connector-j'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/peoplein/moiming/InitDatabaseQuery.java
+++ b/src/main/java/com/peoplein/moiming/InitDatabaseQuery.java
@@ -70,6 +70,7 @@ public class InitDatabaseQuery {
                 passwordEncoder.encode(InitConstant.WOOSEOK_PASS),
                 InitConstant.WOOSEOK_EMAIL,
                 InitConstant.WOOSEOK_NAME,
+                "",
                 InitConstant.WOOSEOK_GENDER,
                 role);
 
@@ -85,6 +86,7 @@ public class InitDatabaseQuery {
                 passwordEncoder.encode(InitConstant.WOOJIN_PASS),
                 InitConstant.WOOJIN_EMAIL,
                 InitConstant.WOOJIN_NAME,
+                "",
                 InitConstant.WOOJIN_GENDER,
                 role);
 
@@ -93,6 +95,7 @@ public class InitDatabaseQuery {
                 passwordEncoder.encode(InitConstant.BYUNGHO_PASS),
                 InitConstant.BYUNGHO_EMAIL,
                 InitConstant.BYUNGHO_NAME,
+                "",
                 InitConstant.BYUNGHO_GENDER,
                 role);
 
@@ -101,6 +104,7 @@ public class InitDatabaseQuery {
                 passwordEncoder.encode(InitConstant.JUBIN_PASS),
                 InitConstant.JUBIN_EMAIL,
                 InitConstant.JUBIN_NAME,
+                "",
                 InitConstant.JUBIN_GENDER,
                 role);
 

--- a/src/main/java/com/peoplein/moiming/MoimingApplication.java
+++ b/src/main/java/com/peoplein/moiming/MoimingApplication.java
@@ -1,13 +1,40 @@
 package com.peoplein.moiming;
 
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 
 @SpringBootApplication
 public class MoimingApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(MoimingApplication.class, args);
+    }
+
+    /*
+     앱 시작시 Firebase 연동 (수명주기중 한 번 수행)
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    public void initFirebaseApp() throws IOException {
+
+        FileInputStream serviceAccount =
+                new FileInputStream("src/main/resources/fcm/moiming-b2ae3-firebase-adminsdk-21zjr-11c77c69f7.json");
+
+        FirebaseOptions options = new FirebaseOptions.Builder()
+                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .build();
+
+        FirebaseApp.initializeApp(options);
+        System.out.println("FIREBASE INITIALIZE COMPLETE");
     }
 
 }

--- a/src/main/java/com/peoplein/moiming/MoimingApplication.java
+++ b/src/main/java/com/peoplein/moiming/MoimingApplication.java
@@ -4,6 +4,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -15,6 +16,8 @@ import java.io.IOException;
 
 @SpringBootApplication
 public class MoimingApplication {
+    @Value("${app_files.fcm_path}")
+    private String fcmFilePath;
 
     public static void main(String[] args) {
         SpringApplication.run(MoimingApplication.class, args);
@@ -27,7 +30,7 @@ public class MoimingApplication {
     public void initFirebaseApp() throws IOException {
 
         FileInputStream serviceAccount =
-                new FileInputStream("src/main/resources/fcm/moiming-b2ae3-firebase-adminsdk-21zjr-11c77c69f7.json");
+                new FileInputStream(fcmFilePath);
 
         FirebaseOptions options = new FirebaseOptions.Builder()
                 .setCredentials(GoogleCredentials.fromStream(serviceAccount))

--- a/src/main/java/com/peoplein/moiming/NetworkSetting.java
+++ b/src/main/java/com/peoplein/moiming/NetworkSetting.java
@@ -11,6 +11,7 @@ public interface NetworkSetting {
 
     String API_MOIM_VER = "/v0";
     String API_MEMBER = "/member";
+
     String API_MOIM = "/moim";
     String API_MOIM_POST = "/post";
     String API_MOIM_POST_COMMENT = "/comment";
@@ -19,5 +20,6 @@ public interface NetworkSetting {
     String API_MOIM_RULES = "/rules";
     String API_MOIM_SESSION = "/session";
 
-
+    String API_NOTI_VER = "/v0";
+    String API_NOTI = "/notification";
 }

--- a/src/main/java/com/peoplein/moiming/controller/AuthController.java
+++ b/src/main/java/com/peoplein/moiming/controller/AuthController.java
@@ -64,8 +64,7 @@ public class AuthController {
             }
     )
     private ResponseModel<MemberResponseDto> signinMember(@RequestBody MemberSigninRequestDto requestDto, HttpServletResponse response) {
-
-        return authService.signin(requestDto, response);
+        MemberResponseDto dto = authService.signin(requestDto, response);
+        return ResponseModel.createResponse(dto);
     }
-
 }

--- a/src/main/java/com/peoplein/moiming/controller/MoimMemberController.java
+++ b/src/main/java/com/peoplein/moiming/controller/MoimMemberController.java
@@ -3,12 +3,14 @@ package com.peoplein.moiming.controller;
 import com.peoplein.moiming.NetworkSetting;
 import com.peoplein.moiming.domain.Member;
 import com.peoplein.moiming.domain.MemberMoimLinker;
+import com.peoplein.moiming.domain.enums.MoimMemberState;
 import com.peoplein.moiming.model.ResponseModel;
 import com.peoplein.moiming.model.dto.domain.MoimMemberInfoDto;
 import com.peoplein.moiming.model.dto.domain.MyMoimLinkerDto;
 import com.peoplein.moiming.model.dto.request.MoimJoinRequestDto;
 import com.peoplein.moiming.model.dto.request.MoimMemberActionRequestDto;
 import com.peoplein.moiming.service.MoimMemberService;
+import com.peoplein.moiming.service.NotificationService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -17,8 +19,8 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequiredArgsConstructor
 @Tag(name = "Moim 내부 회원 관리 관련")
+@RequiredArgsConstructor
 @RequestMapping(NetworkSetting.API_SERVER + NetworkSetting.API_MOIM_VER + NetworkSetting.API_MOIM + NetworkSetting.API_MEMBER)
 public class MoimMemberController {
 
@@ -51,7 +53,7 @@ public class MoimMemberController {
     @PatchMapping("/decideJoin")
     public ResponseModel<MoimMemberInfoDto> decideJoin(@RequestBody MoimMemberActionRequestDto moimMemberActionRequestDto) {
         Member curMember = (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        MemberMoimLinker memberMoimLinker = moimMemberService.decideJoin(moimMemberActionRequestDto);
+        MemberMoimLinker memberMoimLinker = moimMemberService.decideJoin(moimMemberActionRequestDto, curMember);
         MoimMemberInfoDto moimMemberInfoDto = new MoimMemberInfoDto(memberMoimLinker);
         return ResponseModel.createResponse(moimMemberInfoDto);
     }

--- a/src/main/java/com/peoplein/moiming/controller/MoimPostController.java
+++ b/src/main/java/com/peoplein/moiming/controller/MoimPostController.java
@@ -84,7 +84,7 @@ public class MoimPostController {
                             }),
             }
     )
-    @GetMapping("/")
+    @GetMapping("")
     public ResponseModel<List<MoimPostDto>> viewAllMoimPost(@RequestParam(name = "moimId") Long moimId) {
         Member curMember = (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         return ResponseModel.createResponse(moimPostService.viewAllMoimPost(moimId, curMember));

--- a/src/main/java/com/peoplein/moiming/controller/MoimSessionController.java
+++ b/src/main/java/com/peoplein/moiming/controller/MoimSessionController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+
 @RestController
 @RequiredArgsConstructor
 @Tag(name = "Moim 정산 관련")

--- a/src/main/java/com/peoplein/moiming/controller/NotificationController.java
+++ b/src/main/java/com/peoplein/moiming/controller/NotificationController.java
@@ -1,0 +1,37 @@
+package com.peoplein.moiming.controller;
+
+import com.peoplein.moiming.NetworkSetting;
+import com.peoplein.moiming.domain.Member;
+import com.peoplein.moiming.domain.Notification;
+import com.peoplein.moiming.service.NotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Tag(name = "Notification 관련")
+@RequestMapping(NetworkSetting.API_SERVER + NetworkSetting.API_NOTI_VER + NetworkSetting.API_NOTI)
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    public NotificationController(NotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    // 조회와 삭제에 대한 요청 가능
+    // 인증정보로 요청자 판단
+    @Operation(summary = "멤버 모든 알림 조회", description = "멤버의 모든 알림 정보를 반환한다")
+    @GetMapping("")
+    public String viewAllNotification() {
+        Member curMember = (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        notificationService.viewAllNotification(curMember);
+        return "";
+    }
+
+}

--- a/src/main/java/com/peoplein/moiming/domain/Member.java
+++ b/src/main/java/com/peoplein/moiming/domain/Member.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 @Table(uniqueConstraints = {@UniqueConstraint(columnNames = {"uid"}, name = "unique_uid")})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member extends BaseEntity{
+public class Member extends BaseEntity {
 
     /*
      Member Columns
@@ -60,7 +60,7 @@ public class Member extends BaseEntity{
     /*
      생성자는 Private 으로, 생성 방식을 create 함수로만 제어한다
      */
-    private Member(String uid, String password, MemberInfo memberInfo) {
+    private Member(String uid, String password, String fcmToken, MemberInfo memberInfo) {
 
         // TODO : 에러 메세지를 필요하다면 수정해야함.
         if (!StringUtils.hasText(uid) || !StringUtils.hasText(password)) {
@@ -73,6 +73,7 @@ public class Member extends BaseEntity{
 
         this.uid = uid;
         this.password = password;
+        this.fcmToken = fcmToken;
         this.memberInfo = memberInfo;
 
     }
@@ -86,11 +87,12 @@ public class Member extends BaseEntity{
                                       String encryptedPassword,
                                       String email,
                                       String memberName,
+                                      String fcmToken,
                                       MemberGender memberGender,
                                       Role role
-                                      ) {
+    ) {
         MemberInfo memberInfo = new MemberInfo(email, memberName, memberGender);
-        Member createdMember = new Member(uid, encryptedPassword, memberInfo);
+        Member createdMember = new Member(uid, encryptedPassword, fcmToken, memberInfo);
         MemberRoleLinker.grantRoleToMember(createdMember, role);
         return createdMember;
     }
@@ -120,5 +122,11 @@ public class Member extends BaseEntity{
         this.password = password;
     }
 
+    /*
+     필요 Setter Open
+     */
 
+    public void setFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
+    }
 }

--- a/src/main/java/com/peoplein/moiming/domain/Notification.java
+++ b/src/main/java/com/peoplein/moiming/domain/Notification.java
@@ -1,7 +1,8 @@
 package com.peoplein.moiming.domain;
 
 
-import com.google.cloud.storage.Acl;
+import com.peoplein.moiming.domain.enums.NotificationDomain;
+import com.peoplein.moiming.domain.enums.NotificationDomainCategory;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,30 +23,33 @@ public class Notification extends BaseEntity {
     private Long senderId;    // 알림을 보낸 유저의 ID
     private boolean isRead;
     private String notiTitle;
-    private String notiInfo;
+    private String notiBody;
     private Long domainId;
-    private String notiDomain;
-    private String notiCategory; // 각 도메인별 Notification Category 의 종류
+
+    @Enumerated(value = EnumType.STRING)
+    private NotificationDomain notiDomain;
+    @Enumerated(value = EnumType.STRING)
+    private NotificationDomainCategory notiCategory;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    public static Notification createNotification(Long senderId, boolean isRead, String notiTitle, String notiInfo, Long domainId, String notiDomain, String notiCategory, Member member) {
+    public static Notification createNotification(Long senderId, String notiTitle, String notiBody, Long domainId, NotificationDomain notiDomain, NotificationDomainCategory notiCategory, Member member) {
 
-        Notification notification = new Notification(senderId, isRead, notiTitle, notiInfo, domainId, notiDomain, notiCategory, member);
+        Notification notification = new Notification(senderId,  notiTitle, notiBody, domainId, notiDomain, notiCategory, member);
 
         return notification;
     }
 
-    private Notification(Long senderId, boolean isRead, String notiTitle, String notiInfo, Long domainId, String notiDomain, String notiCategory, Member member) {
+    private Notification(Long senderId, String notiTitle, String notiBody, Long domainId, NotificationDomain notiDomain, NotificationDomainCategory notiCategory, Member member) {
 
         // NULL 조건 추가 검증 필요
-        DomainChecker.checkWrongObjectParams(this.getClass().getName(), senderId);
+        DomainChecker.checkWrongObjectParams(this.getClass().getName(), senderId, notiDomain, notiCategory, member);
 
         this.senderId = senderId;
         this.notiTitle = notiTitle;
-        this.notiInfo = notiInfo;
+        this.notiBody = notiBody;
         this.domainId = domainId;
         this.notiDomain = notiDomain;
         this.notiCategory = notiCategory;

--- a/src/main/java/com/peoplein/moiming/domain/Notification.java
+++ b/src/main/java/com/peoplein/moiming/domain/Notification.java
@@ -1,0 +1,63 @@
+package com.peoplein.moiming.domain;
+
+
+import com.google.cloud.storage.Acl;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+// 알림
+@Entity
+@Getter
+@Table(name = "notification")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "notification_id")
+    private Long id;
+    private Long senderId;    // 알림을 보낸 유저의 ID
+    private boolean isRead;
+    private String notiTitle;
+    private String notiInfo;
+    private Long domainId;
+    private String notiDomain;
+    private String notiCategory; // 각 도메인별 Notification Category 의 종류
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    public static Notification createNotification(Long senderId, boolean isRead, String notiTitle, String notiInfo, Long domainId, String notiDomain, String notiCategory, Member member) {
+
+        Notification notification = new Notification(senderId, isRead, notiTitle, notiInfo, domainId, notiDomain, notiCategory, member);
+
+        return notification;
+    }
+
+    private Notification(Long senderId, boolean isRead, String notiTitle, String notiInfo, Long domainId, String notiDomain, String notiCategory, Member member) {
+
+        // NULL 조건 추가 검증 필요
+        DomainChecker.checkWrongObjectParams(this.getClass().getName(), senderId);
+
+        this.senderId = senderId;
+        this.notiTitle = notiTitle;
+        this.notiInfo = notiInfo;
+        this.domainId = domainId;
+        this.notiDomain = notiDomain;
+        this.notiCategory = notiCategory;
+
+        /*
+         초기화
+         */
+        this.isRead = false;
+
+        /*
+         연관관계 매핑
+         */
+        this.member = member;
+    }
+}

--- a/src/main/java/com/peoplein/moiming/domain/enums/NotificationDomain.java
+++ b/src/main/java/com/peoplein/moiming/domain/enums/NotificationDomain.java
@@ -1,0 +1,8 @@
+package com.peoplein.moiming.domain.enums;
+
+public enum NotificationDomain {
+    MOIM,
+    SESSION,
+    SCHEDULE,
+    POST
+}

--- a/src/main/java/com/peoplein/moiming/domain/enums/NotificationDomainCategory.java
+++ b/src/main/java/com/peoplein/moiming/domain/enums/NotificationDomainCategory.java
@@ -18,4 +18,8 @@ public enum NotificationDomainCategory {
 
     // 댓글 달림
     POST_COMMENT,
+
+
+    // 기타
+    DEFAULT
 }

--- a/src/main/java/com/peoplein/moiming/domain/enums/NotificationDomainCategory.java
+++ b/src/main/java/com/peoplein/moiming/domain/enums/NotificationDomainCategory.java
@@ -1,0 +1,21 @@
+package com.peoplein.moiming.domain.enums;
+
+// 각 Type 별 알림의 종류
+public enum NotificationDomainCategory {
+
+    // 모임 가입 완료
+    MOIM_NEW_MEMBER,
+    MOIM_DECLINE_MEMBER,
+
+    // 모임 강퇴
+    MOIM_BAN_MEMBER,
+
+    // 일정 생성
+    SCHEDULE_NEW,
+
+    // 게시물 작성됨
+    POST_NEW,
+
+    // 댓글 달림
+    POST_COMMENT,
+}

--- a/src/main/java/com/peoplein/moiming/model/FcmMessageDto.java
+++ b/src/main/java/com/peoplein/moiming/model/FcmMessageDto.java
@@ -1,0 +1,31 @@
+package com.peoplein.moiming.model;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/*
+ FCM Message Json 변환 Template
+ */
+@Builder
+@Getter
+public class FcmMessageDto {
+
+    private Message message;
+
+    @Builder
+    @Getter
+    public static class Message {
+        private Notification notification;
+        private String token;
+    }
+
+    @Builder
+    @Getter
+    public static class Notification {
+        private String title;
+        private String body;
+        private String image;
+    }
+}

--- a/src/main/java/com/peoplein/moiming/model/dto/auth/MemberSigninRequestDto.java
+++ b/src/main/java/com/peoplein/moiming/model/dto/auth/MemberSigninRequestDto.java
@@ -10,5 +10,6 @@ public class MemberSigninRequestDto {
     private String uid;
     private String password;
     private String email;
+    private String fcmToken;
 
 }

--- a/src/main/java/com/peoplein/moiming/model/dto/domain/NotificationDto.java
+++ b/src/main/java/com/peoplein/moiming/model/dto/domain/NotificationDto.java
@@ -1,0 +1,41 @@
+package com.peoplein.moiming.model.dto.domain;
+
+import com.peoplein.moiming.domain.Member;
+import com.peoplein.moiming.domain.enums.NotificationDomain;
+import com.peoplein.moiming.domain.enums.NotificationDomainCategory;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationDto {
+
+    private Long notificationId;
+    private Long senderId;    // 알림을 보낸 유저의 ID
+    private String notiTitle;
+    private String notiBody;
+    private Long domainId;
+    private NotificationDomain notiDomain;
+    private NotificationDomainCategory notiCategory;
+
+    public NotificationDto(Long notificationId, Long senderId, String notiTitle, String notiBody, Long domainId, NotificationDomain notiDomain, NotificationDomainCategory notiCategory) {
+        this.notificationId = notificationId;
+        this.senderId = senderId;
+        this.notiTitle = notiTitle;
+        this.notiBody = notiBody;
+        this.domainId = domainId;
+        this.notiDomain = notiDomain;
+        this.notiCategory = notiCategory;
+    }
+
+    public void setNotiDomain(NotificationDomain notiDomain) {
+        this.notiDomain = notiDomain;
+    }
+
+    public void setNotiCategory(NotificationDomainCategory notiCategory) {
+        this.notiCategory = notiCategory;
+    }
+}

--- a/src/main/java/com/peoplein/moiming/model/inner/NotificationInput.java
+++ b/src/main/java/com/peoplein/moiming/model/inner/NotificationInput.java
@@ -1,0 +1,25 @@
+package com.peoplein.moiming.model.inner;
+
+import com.peoplein.moiming.domain.enums.NotificationDomain;
+import com.peoplein.moiming.domain.enums.NotificationDomainCategory;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// 생성시 내부적으로 정보 전달을 위한 클래스
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class NotificationInput {
+
+    private Long senderId;
+    private Long domainId;
+    private NotificationDomain notiDomain;
+    private NotificationDomainCategory notiDomainCategory;
+
+    public NotificationInput(Long senderId, Long domainId, NotificationDomain notiDomain, NotificationDomainCategory notiDomainCategory) {
+        this.senderId = senderId;
+        this.domainId = domainId;
+        this.notiDomain = notiDomain;
+        this.notiDomainCategory = notiDomainCategory;
+    }
+}

--- a/src/main/java/com/peoplein/moiming/repository/NotificationRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/NotificationRepository.java
@@ -1,4 +1,8 @@
 package com.peoplein.moiming.repository;
 
+import com.peoplein.moiming.domain.Notification;
+
 public interface NotificationRepository {
+
+    Long save(Notification notification);
 }

--- a/src/main/java/com/peoplein/moiming/repository/NotificationRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/NotificationRepository.java
@@ -1,0 +1,4 @@
+package com.peoplein.moiming.repository;
+
+public interface NotificationRepository {
+}

--- a/src/main/java/com/peoplein/moiming/repository/jpa/NotificationJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/NotificationJpaRepository.java
@@ -1,0 +1,23 @@
+package com.peoplein.moiming.repository.jpa;
+
+
+import com.peoplein.moiming.repository.NotificationRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+
+@Repository
+public class NotificationJpaRepository implements NotificationRepository {
+
+    private final EntityManager em;
+    private final JPAQueryFactory queryFactory;
+
+    public NotificationJpaRepository(EntityManager em, JPAQueryFactory queryFactory) {
+        this.em = em;
+        this.queryFactory = queryFactory;
+    }
+
+
+
+}

--- a/src/main/java/com/peoplein/moiming/repository/jpa/NotificationJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/NotificationJpaRepository.java
@@ -1,6 +1,7 @@
 package com.peoplein.moiming.repository.jpa;
 
 
+import com.peoplein.moiming.domain.Notification;
 import com.peoplein.moiming.repository.NotificationRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;
@@ -19,5 +20,9 @@ public class NotificationJpaRepository implements NotificationRepository {
     }
 
 
-
+    @Override
+    public Long save(Notification notification) {
+        em.persist(notification);
+        return notification.getId();
+    }
 }

--- a/src/main/java/com/peoplein/moiming/service/AuthService.java
+++ b/src/main/java/com/peoplein/moiming/service/AuthService.java
@@ -68,7 +68,6 @@ public class AuthService {
     public ResponseModel<MemberResponseDto> signin(MemberSigninRequestDto memberSigninDto, HttpServletResponse response) {
 
         DomainChecker.checkRightString("Member Signin Request Dto", true, memberSigninDto.getUid(), memberSigninDto.getPassword(), memberSigninDto.getEmail());
-
         checkUniqueColumnDuplication(memberSigninDto.getUid(), memberSigninDto.getEmail());
 
         // TODO : 이거 TEMP로 생성하는게 맞는건가?
@@ -80,6 +79,7 @@ public class AuthService {
                 encodedPassword,
                 memberSigninDto.getEmail(),
                 "TEMP",
+                memberSigninDto.getFcmToken(),
                 MemberGender.N,
                 roleUser);
 

--- a/src/main/java/com/peoplein/moiming/service/AuthService.java
+++ b/src/main/java/com/peoplein/moiming/service/AuthService.java
@@ -65,7 +65,7 @@ public class AuthService {
      4. 토큰 발급, Response 헤더 세팅
      5. ResponseDto 모델 세팅
      */
-    public ResponseModel<MemberResponseDto> signin(MemberSigninRequestDto memberSigninDto, HttpServletResponse response) {
+    public MemberResponseDto signin(MemberSigninRequestDto memberSigninDto, HttpServletResponse response) {
 
         DomainChecker.checkRightString("Member Signin Request Dto", true, memberSigninDto.getUid(), memberSigninDto.getPassword(), memberSigninDto.getEmail());
         checkUniqueColumnDuplication(memberSigninDto.getUid(), memberSigninDto.getEmail());
@@ -90,7 +90,7 @@ public class AuthService {
         // Response 객체 생성
         MemberDto memberDto = MemberDto.createMemberDtoWhenSignIn(signInMember);
         MemberInfoDto memberInfoDto = MemberInfoDto.createMemberInfoDtoWhenSignIn(signInMember.getMemberInfo());
-        return ResponseModel.createResponse(new MemberResponseDto(memberDto, memberInfoDto));
+        return new MemberResponseDto(memberDto, memberInfoDto);
     }
 
 

--- a/src/main/java/com/peoplein/moiming/service/NotificationService.java
+++ b/src/main/java/com/peoplein/moiming/service/NotificationService.java
@@ -6,6 +6,7 @@ import com.peoplein.moiming.domain.Notification;
 import com.peoplein.moiming.domain.enums.NotificationDomain;
 import com.peoplein.moiming.domain.enums.NotificationDomainCategory;
 import com.peoplein.moiming.model.dto.domain.NotificationDto;
+import com.peoplein.moiming.model.inner.NotificationInput;
 import com.peoplein.moiming.repository.NotificationRepository;
 import com.peoplein.moiming.service.shell.NotificationServiceShell;
 import com.peoplein.moiming.service.support.FcmService;
@@ -34,15 +35,16 @@ public class NotificationService {
 
     }
 
-    public void createNotification(NotificationDto notificationDto, Member receiver) {
+    //
+    public void createNotification(NotificationInput notificationInput, Member receiver) {
 
         // 1. 수신된 notificationDto 를 가지고 어떤 noti 인지 파악한다
-        List<String> info = buildTitleAndBody(notificationDto);
+        List<String> info = buildTitleAndBody(notificationInput);
 
         // 2. Notification Entity 를 만들어 저장한다
-        Notification notification = Notification.createNotification(notificationDto.getSenderId()
+        Notification notification = Notification.createNotification(notificationInput.getSenderId()
                 , info.get(0), info.get(1)
-                , notificationDto.getDomainId(), notificationDto.getNotiDomain(), notificationDto.getNotiCategory()
+                , notificationInput.getDomainId(), notificationInput.getNotiDomain(), notificationInput.getNotiDomainCategory()
                 , receiver);
 
         notificationRepository.save(notification);
@@ -57,28 +59,28 @@ public class NotificationService {
 
 
     // Noti 에 대한 정보를 토대로 제목과 내용을 작성한다
-    private List<String> buildTitleAndBody(NotificationDto notificationDto) {
+    private List<String> buildTitleAndBody(NotificationInput notificationInput) {
 
         List<String> res = new ArrayList<>();
+
         String title = "";
         String body = "";
 
         // NotificationDomain 과 Category 에 다른 종류별 MSG BUILD
-        if (notificationDto.getNotiDomain().equals(NotificationDomain.MOIM)) {
+        if (notificationInput.getNotiDomain().equals(NotificationDomain.MOIM)) {
 
-            notificationServiceShell.initMoim(notificationDto.getDomainId());
+            notificationServiceShell.initMoim(notificationInput.getDomainId());
             Moim moim = notificationServiceShell.getMoim();
 
-            if (notificationDto.getNotiCategory().equals(NotificationDomainCategory.MOIM_NEW_MEMBER)) {
+            if (notificationInput.getNotiDomainCategory().equals(NotificationDomainCategory.MOIM_NEW_MEMBER)) {
                 title = "모임 가입 수락 알림";
                 body = moim.getMoimName() + " 모임에서 가입을 수락하였습니다. 지금 바로 모임활동에 참여해보세요";
             }
 
-            if (notificationDto.getNotiCategory().equals(NotificationDomainCategory.MOIM_DECLINE_MEMBER)) {
+            if (notificationInput.getNotiDomainCategory().equals(NotificationDomainCategory.MOIM_DECLINE_MEMBER)) {
                 title = "모임 가입 거절 알림";
                 body = moim.getMoimName() + " 모임에서 가입을 거절하였습니다. 거절 사유를 확인해보세요";
             }
-
         }
 
         res.add(title);

--- a/src/main/java/com/peoplein/moiming/service/NotificationService.java
+++ b/src/main/java/com/peoplein/moiming/service/NotificationService.java
@@ -1,0 +1,21 @@
+package com.peoplein.moiming.service;
+
+import com.peoplein.moiming.domain.Member;
+import com.peoplein.moiming.repository.NotificationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    public NotificationService(NotificationRepository notificationRepository) {
+        this.notificationRepository = notificationRepository;
+    }
+    public void viewAllNotification(Member curMember) {
+
+
+    }
+}

--- a/src/main/java/com/peoplein/moiming/service/NotificationService.java
+++ b/src/main/java/com/peoplein/moiming/service/NotificationService.java
@@ -1,21 +1,89 @@
 package com.peoplein.moiming.service;
 
 import com.peoplein.moiming.domain.Member;
+import com.peoplein.moiming.domain.Moim;
+import com.peoplein.moiming.domain.Notification;
+import com.peoplein.moiming.domain.enums.NotificationDomain;
+import com.peoplein.moiming.domain.enums.NotificationDomainCategory;
+import com.peoplein.moiming.model.dto.domain.NotificationDto;
 import com.peoplein.moiming.repository.NotificationRepository;
+import com.peoplein.moiming.service.shell.NotificationServiceShell;
+import com.peoplein.moiming.service.support.FcmService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Service
-@Transactional(readOnly = true)
+@Transactional
 public class NotificationService {
 
+    private final FcmService fcmService;
     private final NotificationRepository notificationRepository;
+    private final NotificationServiceShell notificationServiceShell;
 
-    public NotificationService(NotificationRepository notificationRepository) {
+    public NotificationService(FcmService fcmService, NotificationRepository notificationRepository, NotificationServiceShell notificationServiceShell) {
+        this.fcmService = fcmService;
         this.notificationRepository = notificationRepository;
+        this.notificationServiceShell = notificationServiceShell;
     }
+
     public void viewAllNotification(Member curMember) {
 
 
+    }
+
+    public void createNotification(NotificationDto notificationDto, Member receiver) {
+
+        // 1. 수신된 notificationDto 를 가지고 어떤 noti 인지 파악한다
+        List<String> info = buildTitleAndBody(notificationDto);
+
+        // 2. Notification Entity 를 만들어 저장한다
+        Notification notification = Notification.createNotification(notificationDto.getSenderId()
+                , info.get(0), info.get(1)
+                , notificationDto.getDomainId(), notificationDto.getNotiDomain(), notificationDto.getNotiCategory()
+                , receiver);
+
+        notificationRepository.save(notification);
+
+        // 3. FCM 을 생성하여 전송한다
+        fcmService.sendSingleMessageTo(notification.getMember().getFcmToken()
+                , notification.getNotiTitle()
+                , notification.getNotiBody());
+
+        // 종료
+    }
+
+
+    // Noti 에 대한 정보를 토대로 제목과 내용을 작성한다
+    private List<String> buildTitleAndBody(NotificationDto notificationDto) {
+
+        List<String> res = new ArrayList<>();
+        String title = "";
+        String body = "";
+
+        // NotificationDomain 과 Category 에 다른 종류별 MSG BUILD
+        if (notificationDto.getNotiDomain().equals(NotificationDomain.MOIM)) {
+
+            notificationServiceShell.initMoim(notificationDto.getDomainId());
+            Moim moim = notificationServiceShell.getMoim();
+
+            if (notificationDto.getNotiCategory().equals(NotificationDomainCategory.MOIM_NEW_MEMBER)) {
+                title = "모임 가입 수락 알림";
+                body = moim.getMoimName() + " 모임에서 가입을 수락하였습니다. 지금 바로 모임활동에 참여해보세요";
+            }
+
+            if (notificationDto.getNotiCategory().equals(NotificationDomainCategory.MOIM_DECLINE_MEMBER)) {
+                title = "모임 가입 거절 알림";
+                body = moim.getMoimName() + " 모임에서 가입을 거절하였습니다. 거절 사유를 확인해보세요";
+            }
+
+        }
+
+        res.add(title);
+        res.add(body);
+
+        return res;
     }
 }

--- a/src/main/java/com/peoplein/moiming/service/shell/NotificationServiceShell.java
+++ b/src/main/java/com/peoplein/moiming/service/shell/NotificationServiceShell.java
@@ -1,0 +1,22 @@
+package com.peoplein.moiming.service.shell;
+
+import com.peoplein.moiming.domain.Moim;
+import com.peoplein.moiming.repository.MoimRepository;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+@RequiredArgsConstructor
+public class NotificationServiceShell {
+
+    private final MoimRepository moimRepository;
+    private Moim moim;
+
+    public void initMoim(Long moimId) {
+
+        moim = moimRepository.findById(moimId);
+
+    }
+}

--- a/src/main/java/com/peoplein/moiming/service/support/FcmService.java
+++ b/src/main/java/com/peoplein/moiming/service/support/FcmService.java
@@ -29,9 +29,9 @@ import java.util.List;
 @Slf4j
 public class FcmService {
 
-    // 초기화 이후 앱 내에서 지속 사용 가능
+    // 초기화 이후 앱 내에서 지속 사용 가능, 단 해당 클래스 내에서만 사용됨
     private String appAccessToken;
-    private String API_URL = "https://fcm.googleapis.com/v1/projects/moiming-b2ae3/messages:send";
+    private static final String API_URL = "https://fcm.googleapis.com/v1/projects/moiming-b2ae3/messages:send";
 
     private final ObjectMapper om = new ObjectMapper();
 
@@ -91,6 +91,7 @@ public class FcmService {
 
         } catch (IOException exception) {
 
+            // TODO : FCM SEND FAILURE HANDLING NEEDED
             log.error("CREATE FCM ERROR :: {}", exception.getMessage());
 
         }

--- a/src/main/java/com/peoplein/moiming/service/support/FcmService.java
+++ b/src/main/java/com/peoplein/moiming/service/support/FcmService.java
@@ -1,0 +1,8 @@
+package com.peoplein.moiming.service.support;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class FcmService {
+
+}

--- a/src/main/java/com/peoplein/moiming/service/support/FcmService.java
+++ b/src/main/java/com/peoplein/moiming/service/support/FcmService.java
@@ -6,6 +6,7 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.peoplein.moiming.model.FcmMessageDto;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.*;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
@@ -31,14 +32,17 @@ public class FcmService {
 
     // 초기화 이후 앱 내에서 지속 사용 가능, 단 해당 클래스 내에서만 사용됨
     private String appAccessToken;
+
     private static final String API_URL = "https://fcm.googleapis.com/v1/projects/moiming-b2ae3/messages:send";
+
+    @Value("${app_files.fcm_path}")
+    private String fcmFilePath;
 
     private final ObjectMapper om = new ObjectMapper();
 
     private void initAccessToken() throws IOException {
-        String firebaseConfigPath = "src/main/resources/fcm/moiming-b2ae3-firebase-adminsdk-21zjr-11c77c69f7.json";
         GoogleCredentials googleCredentials = GoogleCredentials
-                .fromStream(new ClassPathResource(firebaseConfigPath).getInputStream())
+                .fromStream(new ClassPathResource(fcmFilePath).getInputStream())
                 .createScoped(List.of("https://www.googleapis.com/auth/firebase.messaging"));
         googleCredentials.refreshIfExpired();
         appAccessToken = googleCredentials.getAccessToken().getTokenValue();

--- a/src/main/java/com/peoplein/moiming/service/support/FcmService.java
+++ b/src/main/java/com/peoplein/moiming/service/support/FcmService.java
@@ -1,8 +1,94 @@
 package com.peoplein.moiming.service.support;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.peoplein.moiming.model.FcmMessageDto;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.*;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
+import java.io.IOException;
+import java.util.List;
+
+/*
+ 모든 알림 송신을 담당
+ */
+
+/*
+
+ 각 요청 도메인에서 Notification Entity 관리 또한 담당
+ 생성할 Notification 을 토대로 보낼 알림의 Title, Body 을 형성하여 전달
+ 대상의 Receiver Token 또한 같이 전달
+
+ */
 @Service
+@Slf4j
 public class FcmService {
+
+    // 초기화 이후 앱 내에서 지속 사용 가능
+    private String appAccessToken;
+    private String API_URL = "https://fcm.googleapis.com/v1/projects/moiming-b2ae3/messages:send";
+
+    private final ObjectMapper om = new ObjectMapper();
+
+    private void initAccessToken() throws IOException {
+        String firebaseConfigPath = "src/main/resources/fcm/moiming-b2ae3-firebase-adminsdk-21zjr-11c77c69f7.json";
+        GoogleCredentials googleCredentials = GoogleCredentials
+                .fromStream(new ClassPathResource(firebaseConfigPath).getInputStream())
+                .createScoped(List.of("https://www.googleapis.com/auth/firebase.messaging"));
+        googleCredentials.refreshIfExpired();
+        appAccessToken = googleCredentials.getAccessToken().getTokenValue();
+    }
+
+
+    public String buildMessage(String receiverToken, String title, String body) throws IOException {
+
+        FcmMessageDto.Notification notification = FcmMessageDto.Notification.builder()
+                .title(title)
+                .body(body)
+                .build();
+
+        FcmMessageDto.Message message = FcmMessageDto.Message.builder()
+                .token(receiverToken)
+                .notification(notification)
+                .build();
+
+        FcmMessageDto fcmMessageDto = FcmMessageDto.builder()
+                .message(message)
+                .build();
+
+        return om.writeValueAsString(fcmMessageDto);
+
+    }
+
+    public void sendSingleMessageTo(String receiverToken, String title, String body) throws IOException {
+
+        if (!StringUtils.hasText(appAccessToken)) {
+            initAccessToken();
+        }
+
+        String message = buildMessage(receiverToken, title, body);
+
+        OkHttpClient client = new OkHttpClient();
+        RequestBody requestBody = RequestBody.create(message, MediaType.get("application/json; charset=utf-8"));
+        Request request = new Request.Builder()
+                .url(API_URL)
+                .post(requestBody)
+                .addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + appAccessToken)
+                .addHeader(HttpHeaders.CONTENT_TYPE, "application/json; UTF-8")
+                .build();
+
+        Response response = client.newCall(request).execute();
+
+        log.info("FCM SENT:: RESPONSE:: {}", response.body().string());
+
+    }
+
+    public void sendBatchMessageTo(List<String> receiverToken, String title, String body) throws IOException {
+
+    }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,3 +32,6 @@ spring:
     defer-datasource-initialization: true
     generate-ddl: true
     open-in-view: false
+
+app_files:
+  fcm_path: src/main/resources/fcm/moiming-b2ae3-firebase-adminsdk-21zjr-11c77c69f7.json

--- a/src/main/resources/fcm/moiming-b2ae3-firebase-adminsdk-21zjr-11c77c69f7.json
+++ b/src/main/resources/fcm/moiming-b2ae3-firebase-adminsdk-21zjr-11c77c69f7.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "moiming-b2ae3",
+  "private_key_id": "11c77c69f7b403595f353c7afb04939be4b08c3c",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQCazLd5TlKRNEAb\nfEzvVIGweWXSB9hYiKYhGfZREO4ZmztiNX4DWivU6R5M1ix/AAWVuXIFJDAG29tc\n9S1bBPRLiTwSA5M9cu0zU3vlznx0fTkV7PkR+5PU4gu7JNA+aOE569V5SP2TOIkX\nCs7c9rDUl4YnuoIlAI0j7iwcA0lkrB1wy8wvuYiJyXGAXXMHQzSrX7wsEhRwXBZj\nILApAlUEzU2GJgnDkvBbGVXNjcC80VZI9seK7k3x6XXDuo2SdQyqHSN40BOZfEfe\nl1An8kppMAUeOQrEbrFGemSBg6tM8TFpeXpiDIQiY9qP+FHTc5R2CUCJ/LC0WO2l\ne6G8l5bbAgMBAAECggEAErf25w4fsYZMyuYPfuX29BTh8/FV6cgbCqf93z9PA2gA\nLiKDdTql+o4hR1pOBszFCsi3bxlj+K2voNXW9l7Vfv1+duaEG1X2ipJ+9MLbeCdH\noWKb8F7oY+wyTfQoKFEnYbPRBw8FTBRLONmU5ScBgAY98eI9kuWLq6YaeF1fYR23\ndqDVmYatAOiHbKNRbZLALXKEaSAsgP++tFTySM0fBKXEaa3lzNR83j99HiY63CXT\nShbcrTRO12p1z4/yt4taxB/aMLAlTmHaMqEEp8snZUEs6V1w5WKtZRgHP0MdKqpU\nG9JJqziKyb4o1rqn3mKwAb89pkeJrdERJt327ui0hQKBgQDHyVcS3HXlh2xk2m7j\nPJC5gOXFgaOpV/52aipaXaavZIszIDbO/YVCaqfYh0RipBBFSHTWJwvr6KD3vzc4\nX0HDORRYq9NRYwZqvmlMOFqqS4Zdpfa/uvVgLz8/naEZ718Kj+bZ4nzINa5U5GPp\nvAemTnD5o9z/p6k+Q8kTdFElxQKBgQDGWve+uXVQL4iUE0V+Y5sCiGXi18nB+w2R\n+MpcZHasuV7QSO06OPbCU25qAaWDV1o2y2KLzIFQlcsyG+iXBif522wSgKHr3KFF\nkEbY+9NIsHl6l+6TU74hXqPz3vf3QKduUQuX2feA4tpRkBhQmwIXXuVVv0MSGBIZ\nSRQUyDg0HwKBgQC825d0PPM2Bs5wiAxKwvYMZczO573OV2A0kCd5RQ5Mvr7XlZw6\nD23pWulPxo7esDixRc0so7yhRUbk691HbMS9xzd0mvkn9nQac+UWKC+My9g4rqqS\nlClgw0kG2ftwiNdPJLkVPwS2PgiON1g7m4OfsocZdc1z3wod0fZCbbJIAQKBgQCb\n+HnoyhIaLFZcAU9a093WvwRGvGGUm+GOz6/nuMOsi9KnO0D20EYQheRDjOnl/jEc\n9w6VWQiyIid2ToW1A405pjUz01v/iCxz88AR7Oq1tLbBFGjwBiByQuXu5HvdO0Ss\ntSPFkwpQmZEMI59K+qhJUkBJDa0itDS/FzyoHsw7BwKBgQCh67nDylDUe9w6/PAO\nToVqZJTkAOGrDaL4Taq85LN7hvcVWSqdhPzh+tDIU8KGdWU73hEjgFblSiVqM+pq\nQB5XqArAtxR39RZW5Ve4sUSRhd8lKFvjTCNl9/vVeIbitbna08pvESyh6wHds6a3\n0gRhFisVAe/aK+ScbBcYYmbF7g==\n-----END PRIVATE KEY-----\n",
+  "client_email": "firebase-adminsdk-21zjr@moiming-b2ae3.iam.gserviceaccount.com",
+  "client_id": "115201685123630168107",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/firebase-adminsdk-21zjr%40moiming-b2ae3.iam.gserviceaccount.com"
+}

--- a/src/test/java/com/peoplein/moiming/TestUtils.java
+++ b/src/test/java/com/peoplein/moiming/TestUtils.java
@@ -89,7 +89,6 @@ public class TestUtils {
     public static boolean DUPLICATED_MANAGER_ENABLE = true;
 
 
-
     public static Member initOtherMemberAndMemberInfo() {
         Role role = initUserRole();
 
@@ -97,6 +96,7 @@ public class TestUtils {
                 , "other" + password
                 , "other" + memberEmail
                 , "other" + memberName
+                , "other" + fcmToken
                 , memberGender, role);
         member.getMemberInfo().setMemberBirth(memberBirth);
 
@@ -106,7 +106,7 @@ public class TestUtils {
     public static Member initMemberAndMemberInfo() {
         Role role = initAdminRole();
 
-        Member member = Member.createMember(uid, password, memberEmail, memberName, memberGender, role);
+        Member member = Member.createMember(uid, password, memberEmail, memberName, fcmToken, memberGender, role);
         member.getMemberInfo().setMemberBirth(memberBirth);
 
         return member;
@@ -120,7 +120,6 @@ public class TestUtils {
     public static Role initUserRole() {
         return new Role(2L, "admin", RoleType.USER);
     }
-
 
 
     public static Moim initMoimAndRuleJoin() {

--- a/src/test/java/com/peoplein/moiming/domain/MemberTest.java
+++ b/src/test/java/com/peoplein/moiming/domain/MemberTest.java
@@ -41,7 +41,7 @@ public class MemberTest {
 
         // when
         Member member = Member.createMember(TestUtils.uid, encryptedPassword, TestUtils.memberEmail,
-                TestUtils.memberName, TestUtils.memberGender, role);
+                TestUtils.memberName, TestUtils.fcmToken, TestUtils.memberGender, role);
 
         // then
         assertThat(member.getUid()).isEqualTo(TestUtils.uid);
@@ -57,17 +57,17 @@ public class MemberTest {
 
         // when + then
         assertThatThrownBy(() -> Member.createMember(
-                null, password, TestUtils.memberEmail, TestUtils.memberName, TestUtils.memberGender, role)).isInstanceOf(IllegalArgumentException.class);
+                null, password, TestUtils.memberEmail, TestUtils.memberName, TestUtils.fcmToken, TestUtils.memberGender, role)).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> Member.createMember(
-                TestUtils.uid, null, TestUtils.memberEmail, TestUtils.memberName, TestUtils.memberGender, role)).isInstanceOf(IllegalArgumentException.class);
+                TestUtils.uid, null, TestUtils.memberEmail, TestUtils.memberName, TestUtils.fcmToken, TestUtils.memberGender, role)).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> Member.createMember(
-                TestUtils.uid, TestUtils.encryptedPassword, null, TestUtils.memberName, TestUtils.memberGender, role)).isInstanceOf(BadAuthParameterInputException.class);
+                TestUtils.uid, TestUtils.encryptedPassword, null, TestUtils.memberName, TestUtils.fcmToken, TestUtils.memberGender, role)).isInstanceOf(BadAuthParameterInputException.class);
         assertThatThrownBy(() -> Member.createMember(
-                TestUtils.uid, TestUtils.encryptedPassword, TestUtils.memberEmail, null, TestUtils.memberGender, role)).isInstanceOf(BadAuthParameterInputException.class);
+                TestUtils.uid, TestUtils.encryptedPassword, TestUtils.memberEmail, null, TestUtils.fcmToken, TestUtils.memberGender, role)).isInstanceOf(BadAuthParameterInputException.class);
         assertThatThrownBy(() -> Member.createMember(
-                TestUtils.uid, TestUtils.encryptedPassword, TestUtils.memberEmail, TestUtils.memberName, null, role)).isInstanceOf(IllegalArgumentException.class);
+                TestUtils.uid, TestUtils.encryptedPassword, TestUtils.memberEmail, TestUtils.memberName, TestUtils.fcmToken, null, role)).isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> Member.createMember(
-                TestUtils.uid, TestUtils.encryptedPassword, TestUtils.memberEmail, TestUtils.memberName, TestUtils.memberGender, null)).isInstanceOf(NullPointerException.class);
+                TestUtils.uid, TestUtils.encryptedPassword, TestUtils.memberEmail, TestUtils.memberName, TestUtils.fcmToken, TestUtils.memberGender, null)).isInstanceOf(NullPointerException.class);
     }
 
     @Test
@@ -76,7 +76,7 @@ public class MemberTest {
         String changedToken = "NEW_REFRESH_TOKEN";
         Role role = new Role(1L, "admin", RoleType.ADMIN);
         Member member = Member.createMember(TestUtils.uid, TestUtils.password, TestUtils.memberEmail,
-                TestUtils.memberName, TestUtils.memberGender, role);
+                TestUtils.memberName, TestUtils.fcmToken, TestUtils.memberGender, role);
 
         // when
         member.changeRefreshToken(changedToken);
@@ -91,7 +91,7 @@ public class MemberTest {
         String sameToken = TestUtils.refreshToken;
         Role role = new Role(1L, "admin", RoleType.ADMIN);
         Member member = Member.createMember(TestUtils.uid, TestUtils.password, TestUtils.memberEmail,
-                TestUtils.memberName, TestUtils.memberGender, role);
+                TestUtils.memberName, TestUtils.fcmToken, TestUtils.memberGender, role);
 
         // when
         member.changeRefreshToken(sameToken);

--- a/src/test/java/com/peoplein/moiming/domain/MoimTest.java
+++ b/src/test/java/com/peoplein/moiming/domain/MoimTest.java
@@ -343,7 +343,7 @@ public class MoimTest {
         Role role = new Role(1L, "admin", RoleType.USER);
 
         Member member = Member.createMember(TestUtils.uid, TestUtils.password, TestUtils.memberEmail,
-                TestUtils.memberName, TestUtils.memberGender, role);
+                TestUtils.memberName, TestUtils.fcmToken, TestUtils.memberGender, role);
 
         member.getMemberInfo().setMemberBirth(memberBirth);
 

--- a/src/test/java/com/peoplein/moiming/integration/AuthIntegrationTest.java
+++ b/src/test/java/com/peoplein/moiming/integration/AuthIntegrationTest.java
@@ -80,7 +80,7 @@ public class AuthIntegrationTest extends BaseTest {
     void 회원가입() throws Exception {
 
         //given
-        MemberSigninRequestDto signinRequestDto = new MemberSigninRequestDto("jypark1234", "1234", "j@moiming.net");
+        MemberSigninRequestDto signinRequestDto = new MemberSigninRequestDto("jypark1234", "1234", "j@moiming.net", TestUtils.fcmToken);
 
         //when
         url += "/signin";
@@ -113,7 +113,7 @@ public class AuthIntegrationTest extends BaseTest {
     void 회원가입_실패_중복_UID() throws Exception {
 
         //given
-        MemberSigninRequestDto signinRequestDto = new MemberSigninRequestDto("wrock.kang", "1234", "kws8643@naver.com");
+        MemberSigninRequestDto signinRequestDto = new MemberSigninRequestDto("wrock.kang", "1234", "kws8643@naver.com", TestUtils.fcmToken);
 
         //when
         url += "/signin";
@@ -139,7 +139,7 @@ public class AuthIntegrationTest extends BaseTest {
     void 회원가입_실패_중복_EMAIL() throws Exception {
 
         //given
-        MemberSigninRequestDto signinRequestDto = new MemberSigninRequestDto("jypark1234", "1234", "a@moiming.net");
+        MemberSigninRequestDto signinRequestDto = new MemberSigninRequestDto("jypark1234", "1234", "a@moiming.net", TestUtils.fcmToken);
 
         //when
         url += "/signin";

--- a/src/test/java/com/peoplein/moiming/repository/jpa/UtilsRepository.java
+++ b/src/test/java/com/peoplein/moiming/repository/jpa/UtilsRepository.java
@@ -57,7 +57,7 @@ public class UtilsRepository {
 
     public static Member initMemberAndMemberInfo() {
         Role role = new Role(1L, "admin", RoleType.ADMIN);
-        return Member.createMember(uid, password, memberEmail, memberName, memberGender, role);
+        return Member.createMember(uid, password, memberEmail, memberName, fcmToken, memberGender, role);
     }
 
     public static Moim initMoim() {

--- a/src/test/java/com/peoplein/moiming/service/MoimMemberIntegrationServiceTest.java
+++ b/src/test/java/com/peoplein/moiming/service/MoimMemberIntegrationServiceTest.java
@@ -172,7 +172,7 @@ public class MoimMemberIntegrationServiceTest extends BaseTest {
         MoimMemberActionRequestDto actionRequestDto = TestUtils.createActionRequestDto(moim.getId(), member.getId(), MoimMemberStateAction.PERMIT);
 
         // when
-        MemberMoimLinker result = moimMemberService.decideJoin(actionRequestDto);
+        MemberMoimLinker result = moimMemberService.decideJoin(actionRequestDto, member);
 
         // then
         assertThat(result.getMemberState()).isEqualTo(MoimMemberState.ACTIVE);


### PR DESCRIPTION
<h2> Notification Domain 추가 </h2>

- 앱 내 활동으로 인해 발생할 Notification 들을 저장할 notification domain 추가
- 현재 생성만 작성됨. (조회, 삭제 까지만 추가될 예정) 
- 생성은 직접 생성이 아닌, 활동으로 인한 생성
- Notification Domain 은 어떤 활동의 알림인지, NotificationDomain Category 는 활동 내 어떤 알림인지에 대한 내용 (추후 알림 선택시 해당 활동 (모임, 정산활동, 일정 등) 으로 이동시켜줘야 하고, Category 는 알림 내용의 구체화를 위해 설정 )
</br>
<h2> FCM 활동 추가 1</h2>

- FCM 활동을 위한 Firebase Console 에서 제공해주는 admin key file 추가 (git ignore 필요할듯 함) 
- 사용자들 기기별로 FCM Token 이 생성되어야 하는데, Token 생성 로직은 Client side 에서 추가하고 토큰을 서버에 전달해 주는 방식으로 진행 
- FCM 기기토큰은  사용자 접속 (로그인, 자동로그인),  회원가입 진행마다 새로 발급받아 DB에 저장하되, 로그아웃시에는 DB에서 삭제한다  
- 기기 토큰 관리는 Client Side 미개발, Splash 화면 로직 미개발로 인해 대기 
- MainAppplication.java 파일에 앱 시작시 1회 Firebase Init 진행 (admin key file 로 진행됨) 
</br>
<h2> FCM 활동 추가 2 - FcmService Class 에 대해 </h2>

- 모든 FCM 을 보내는 Service Class
- 알림 제목, 알림 내용, 알림 대상만을 받고 정말 FCM 을 보내는 역할만 한다 
- 기기별 알림 전송이 구현되어 있으나, 단체 알림 전송 현재 미구현 (모임 대상, 정산활동 대상원들에 대해 구현 필요 예상) 
- 아직 FCM 관련되어서는 TEST 진행되지 않음 (기기별 FCM Token 구현 필요 - Client Side 개발 후 Test 필요) 

</br>
<h2> Notification 생성 - FCM 전송 활동 예시 추가 </h2>

- MoimMemberController 에서 모임 활동 가입 요청 처리에 대한 Notifcation - FCM 로직 예시로서 추가해둠
- Notification 이 필요한 시점에 NotificationDto를 생성하여 필요 Data 를 넣어 NotificationService 에 전달한다. 
- Notification Service 에서 필요한 title, body 등을 생성후, 저장한 다음에 FCM 을 생성한다. 
</br>