### PR TITLE
정산활동 도메인 개발

### DIFF
--- a/src/main/java/com/peoplein/moiming/InitDatabase.java
+++ b/src/main/java/com/peoplein/moiming/InitDatabase.java
@@ -143,5 +143,11 @@ public class InitDatabase {
     public void initSessionCategories() {
         initDatabaseQuery.initSessionCategories();
     }
+
+    @EventListener(ApplicationReadyEvent.class)
+    @Order(17)
+    public void initSampleSession() {
+        initDatabaseQuery.initSampleSession();
+    }
 }
 

--- a/src/main/java/com/peoplein/moiming/InitDatabaseQuery.java
+++ b/src/main/java/com/peoplein/moiming/InitDatabaseQuery.java
@@ -7,6 +7,10 @@ import com.peoplein.moiming.domain.fixed.*;
 import com.peoplein.moiming.domain.rules.MoimRule;
 import com.peoplein.moiming.domain.rules.RuleJoin;
 import com.peoplein.moiming.domain.rules.RulePersist;
+import com.peoplein.moiming.domain.session.MemberSessionCategoryLinker;
+import com.peoplein.moiming.domain.session.MemberSessionLinker;
+import com.peoplein.moiming.domain.session.MoimSession;
+import com.peoplein.moiming.domain.session.SessionCategoryItem;
 import com.peoplein.moiming.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +37,7 @@ public class InitDatabaseQuery {
     private final MoimRepository moimRepository;
     private final MoimReviewRepository moimReviewRepository;
     private final RoleRepository roleRepository;
+    private final SessionCategoryRepository sessionCategoryRepository;
 
     public InitDatabaseQuery(EntityManager em,
                              PasswordEncoder passwordEncoder,
@@ -40,7 +45,8 @@ public class InitDatabaseQuery {
                              MemberRepository memberRepository,
                              MoimRepository moimRepository,
                              MoimReviewRepository moimReviewRepository,
-                             RoleRepository roleRepository) {
+                             RoleRepository roleRepository,
+                             SessionCategoryRepository sessionCategoryRepository) {
         this.em = em;
         this.passwordEncoder = passwordEncoder;
         this.categoryRepository = categoryRepository;
@@ -48,6 +54,7 @@ public class InitDatabaseQuery {
         this.moimRepository = moimRepository;
         this.moimReviewRepository = moimReviewRepository;
         this.roleRepository = roleRepository;
+        this.sessionCategoryRepository = sessionCategoryRepository;
     }
 
     private Long moim1Id;
@@ -422,8 +429,9 @@ public class InitDatabaseQuery {
     }
 
     public void initSessionCategories() {
+
         SessionCategory sessionCategory1 = SessionCategory.createSessionCategory(SessionCategoryType.ACTIVITY);
-        SessionCategory sessionCategory2= SessionCategory.createSessionCategory(SessionCategoryType.FOOD);
+        SessionCategory sessionCategory2 = SessionCategory.createSessionCategory(SessionCategoryType.FOOD);
         SessionCategory sessionCategory3 = SessionCategory.createSessionCategory(SessionCategoryType.ALCOHOL);
         SessionCategory sessionCategory4 = SessionCategory.createSessionCategory(SessionCategoryType.DRINKS);
         SessionCategory sessionCategory5 = SessionCategory.createSessionCategory(SessionCategoryType.EXTRA);
@@ -435,8 +443,99 @@ public class InitDatabaseQuery {
         em.persist(sessionCategory5);
     }
 
+    public void initSampleSession() {
+
+        Moim moim = moimRepository.findById(moim1Id);
+
+        Member member1 = memberRepository.findMemberByUid(InitConstant.WOOSEOK_UID);
+        Member member2 = memberRepository.findMemberByUid(InitConstant.WOOJIN_UID);
+        Member member3 = memberRepository.findMemberByUid(InitConstant.BYUNGHO_UID);
+
+        List<SessionCategory> sessionCategories = sessionCategoryRepository.findAllSessionCategories();
+
+        MoimSession moimSession = MoimSession.createMoimSession("예제 정산활동입니다", "예제를 좋아하는 개발자의 예제입니다", 200000, 3, InitConstant.WOOSEOK_UID, moim, null);
+
+        SessionCategoryItem itemActivityRent = SessionCategoryItem.createSessionCategoryItem("렌트비", 60000
+                , moimSession, findSessionCategory(sessionCategories, SessionCategoryType.ACTIVITY));
+
+        SessionCategoryItem itemActivityDrink = SessionCategoryItem.createSessionCategoryItem("음료비", 30000
+                , moimSession, findSessionCategory(sessionCategories, SessionCategoryType.ACTIVITY));
+
+
+        SessionCategoryItem itemFoodChicken = SessionCategoryItem.createSessionCategoryItem("치킨", 30000
+                , moimSession, findSessionCategory(sessionCategories, SessionCategoryType.FOOD));
+        SessionCategoryItem itemFoodPot = SessionCategoryItem.createSessionCategoryItem("감자", 20000
+                , moimSession, findSessionCategory(sessionCategories, SessionCategoryType.FOOD));
+        // DEFAULT 는 FE 에서 자동으로 생성해서 보내준 항목
+        SessionCategoryItem itemFoodDefault = SessionCategoryItem.createSessionCategoryItem("기타", 10000
+                , moimSession, findSessionCategory(sessionCategories, SessionCategoryType.FOOD));
+
+        SessionCategoryItem itemAlcSoju = SessionCategoryItem.createSessionCategoryItem("소주", 30000
+                , moimSession, findSessionCategory(sessionCategories, SessionCategoryType.ALCOHOL));
+        SessionCategoryItem itemAlcBeer = SessionCategoryItem.createSessionCategoryItem("맥주", 10000
+                , moimSession, findSessionCategory(sessionCategories, SessionCategoryType.ALCOHOL));
+
+        // EXTRA 는 FE 에서 자동으로 생성해서 보내준 항목
+        SessionCategoryItem itemExtraDefault = SessionCategoryItem.createSessionCategoryItem("기타", 10000
+                , moimSession, findSessionCategory(sessionCategories, SessionCategoryType.EXTRA));
+
+
+        /// 해당 유저와 정산활동을 연결 (인원별 총 금액에 대하여)
+        MemberSessionLinker wsLinker = MemberSessionLinker.createMemberSessionLinker(70000, MemberSessionState.UNSENT, member1, moimSession);
+        MemberSessionLinker bhLinker = MemberSessionLinker.createMemberSessionLinker(70000, MemberSessionState.UNSENT, member2, moimSession);
+        MemberSessionLinker wjLinker = MemberSessionLinker.createMemberSessionLinker(60000, MemberSessionState.UNSENT, member3, moimSession);
+
+        // 각각 무슨 항목에 해당하는지 연결
+        new MemberSessionCategoryLinker(wsLinker, findSessionCategory(sessionCategories, SessionCategoryType.ACTIVITY));
+        new MemberSessionCategoryLinker(bhLinker, findSessionCategory(sessionCategories, SessionCategoryType.ACTIVITY));
+        new MemberSessionCategoryLinker(wjLinker, findSessionCategory(sessionCategories, SessionCategoryType.ACTIVITY));
+
+        new MemberSessionCategoryLinker(wsLinker, findSessionCategory(sessionCategories, SessionCategoryType.FOOD));
+        new MemberSessionCategoryLinker(bhLinker, findSessionCategory(sessionCategories, SessionCategoryType.FOOD));
+        new MemberSessionCategoryLinker(wjLinker, findSessionCategory(sessionCategories, SessionCategoryType.FOOD));
+
+        new MemberSessionCategoryLinker(wsLinker, findSessionCategory(sessionCategories, SessionCategoryType.ALCOHOL));
+        new MemberSessionCategoryLinker(bhLinker, findSessionCategory(sessionCategories, SessionCategoryType.ALCOHOL));
+
+        new MemberSessionCategoryLinker(wjLinker, findSessionCategory(sessionCategories, SessionCategoryType.EXTRA));
+
+        em.persist(moimSession);
+
+        // 정산 예제 //
+        // 총 정산 금액 200,000
+        // 정산 카테고리  > 정산 내역
+
+        // Front 단 자동 로직 >> 아무 Item 이 없을시 DEFAULT 로 Item 하나 생성
+        //                 >> 아무 정산 Category 없을시 ALL EXTRA 로> Extra 의 DEFAULT
+
+        // ACTIVITY 90,000 > 참여자 강우석, 김우진, 박병호
+        // 렌트비 60,000
+        // 음료비 30,000
+
+        // FOOD 60,000 > 강우석, 김우진, 박병호
+        // 치킨 30,000
+        // 감자 20,000
+        // 기타 10,000
+
+        // ALCOHOL 40,000 > 강우석, 박병호
+        // 소주 30,000
+        // 맥주 10,000
+
+        // EXTRA  10,000 > 김우진
+
+        // 강우석 7
+        // 박병호 7
+        // 김우진 6
+
+
+    }
+
     private ReviewQuestion findReviewQuestion(List<ReviewQuestion> reviewQuestions, QuestionName questionName) {
         return reviewQuestions.stream().filter(q -> q.getQuestionName().equals(questionName)).findAny().orElseThrow(() -> new RuntimeException(questionName + " 이런 질문 없습니다"));
+    }
+
+    private SessionCategory findSessionCategory(List<SessionCategory> sessionCategories, SessionCategoryType sessionCategoryType) {
+        return sessionCategories.stream().filter(sc -> sc.getCategoryType().equals(sessionCategoryType)).findAny().orElseThrow(() -> new RuntimeException("정산 카테고리를 찾을 수 없습니다"));
     }
 
 

--- a/src/main/java/com/peoplein/moiming/InitDatabaseQuery.java
+++ b/src/main/java/com/peoplein/moiming/InitDatabaseQuery.java
@@ -246,9 +246,11 @@ public class InitDatabaseQuery {
         Moim moim = moimRepository.findById(moim1Id);
         Member curMember = memberRepository.findMemberByUid(InitConstant.WOOJIN_UID);
         Member curMember2 = memberRepository.findMemberByUid(InitConstant.BYUNGHO_UID);
+        Member curMember3 = memberRepository.findMemberByUid(InitConstant.JUBIN_UID);
 
         MemberMoimLinker.memberJoinMoim(curMember, moim, MoimRoleType.NORMAL, MoimMemberState.ACTIVE);
         MemberMoimLinker.memberJoinMoim(curMember2, moim, MoimRoleType.NORMAL, MoimMemberState.ACTIVE);
+        MemberMoimLinker.memberJoinMoim(curMember3, moim, MoimRoleType.NORMAL, MoimMemberState.ACTIVE);
     }
 
 
@@ -433,7 +435,7 @@ public class InitDatabaseQuery {
         SessionCategory sessionCategory1 = SessionCategory.createSessionCategory(SessionCategoryType.ACTIVITY);
         SessionCategory sessionCategory2 = SessionCategory.createSessionCategory(SessionCategoryType.FOOD);
         SessionCategory sessionCategory3 = SessionCategory.createSessionCategory(SessionCategoryType.ALCOHOL);
-        SessionCategory sessionCategory4 = SessionCategory.createSessionCategory(SessionCategoryType.DRINKS);
+        SessionCategory sessionCategory4 = SessionCategory.createSessionCategory(SessionCategoryType.DRINK);
         SessionCategory sessionCategory5 = SessionCategory.createSessionCategory(SessionCategoryType.EXTRA);
 
         em.persist(sessionCategory1);

--- a/src/main/java/com/peoplein/moiming/controller/MoimSessionController.java
+++ b/src/main/java/com/peoplein/moiming/controller/MoimSessionController.java
@@ -4,7 +4,9 @@ package com.peoplein.moiming.controller;
 import com.peoplein.moiming.NetworkSetting;
 import com.peoplein.moiming.domain.Member;
 import com.peoplein.moiming.model.ResponseModel;
+import com.peoplein.moiming.model.dto.domain.MemberSessionLinkerDto;
 import com.peoplein.moiming.model.dto.domain.MoimSessionDto;
+import com.peoplein.moiming.model.dto.request.MemberSessionStateRequestDto;
 import com.peoplein.moiming.model.dto.request.MoimSessionRequestDto;
 import com.peoplein.moiming.model.dto.response.MoimSessionResponseDto;
 import com.peoplein.moiming.service.MoimSessionService;
@@ -71,6 +73,22 @@ public class MoimSessionController {
         Member curMember = (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         moimSessionService.deleteMoimSession(sessionId, curMember);
         return ResponseModel.createResponse("OK");
+    }
+
+    /*
+     정산활동 멤버 상태변경
+     */
+    @PatchMapping("/{sessionId}/member/{memberId}/status")
+    public ResponseModel<MemberSessionLinkerDto> changeSessionMemberStatus(@PathVariable(name = "sessionId") Long sessionId
+            , @PathVariable(name = "memberId") Long memberId
+            , @RequestParam(name = "moimId") Long moimId
+            , @RequestBody MemberSessionStateRequestDto memberSessionStateRequestDto) {
+
+        // 내가 나에 대한 변경을 요청하는 것일 수도, 관리자가 하는 것일 수도 있음
+        // 일단은 "완료" / "미완료" 만 변경할 수 있으므로 only 관리자일 뿐인듯
+        Member curMember = (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        MemberSessionLinkerDto responseDto = moimSessionService.changeSessionMemberStatus(moimId, sessionId, memberId, memberSessionStateRequestDto, curMember);
+        return ResponseModel.createResponse(responseDto);
     }
 
 

--- a/src/main/java/com/peoplein/moiming/controller/MoimSessionController.java
+++ b/src/main/java/com/peoplein/moiming/controller/MoimSessionController.java
@@ -37,9 +37,9 @@ public class MoimSessionController {
      모임 내 모든 정산활동 기본 정보 조회 - moim/session?moimId={}
      */
     @GetMapping("")
-    public List<MoimSessionDto> getAllMoimSessions(@RequestParam(name = "moimId") Long moimId) {
+    public ResponseModel<List<MoimSessionDto>> getAllMoimSessions(@RequestParam(name = "moimId") Long moimId) {
         Member curMember = (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        return moimSessionService.getAllMoimSessions(moimId, curMember);
+        return ResponseModel.createResponse(moimSessionService.getAllMoimSessions(moimId, curMember));
     }
 
     /*s
@@ -48,13 +48,15 @@ public class MoimSessionController {
     @GetMapping("/{sessionId}")
     public MoimSessionResponseDto getMoimSession(@PathVariable(name = "sessionId") Long sessionId) {
         Member curMember = (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        System.out.println(sessionId);
         return moimSessionService.getMoimSession(sessionId, curMember);
     }
 
     /*
      정산활동 수정
      */
-    @PatchMapping("/update")
+    // Patch 가 아닌 PUT 으로 업데이트 진행
+    @PutMapping("/update")
     public ResponseModel<MoimSessionResponseDto> updateMoimSession(@RequestBody MoimSessionRequestDto moimSessionRequestDto) {
         Member curMember = (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         MoimSessionResponseDto moimSessionResponseDto = moimSessionService.updateMoimSession(moimSessionRequestDto, curMember);

--- a/src/main/java/com/peoplein/moiming/controller/MoimSessionController.java
+++ b/src/main/java/com/peoplein/moiming/controller/MoimSessionController.java
@@ -55,9 +55,10 @@ public class MoimSessionController {
      정산활동 수정
      */
     @PatchMapping("/update")
-    public void updateMoimSession(@RequestBody MoimSessionRequestDto moimSessionRequestDto) {
+    public ResponseModel<MoimSessionResponseDto> updateMoimSession(@RequestBody MoimSessionRequestDto moimSessionRequestDto) {
         Member curMember = (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        moimSessionService.updateMoimSession(moimSessionRequestDto, curMember);
+        MoimSessionResponseDto moimSessionResponseDto = moimSessionService.updateMoimSession(moimSessionRequestDto, curMember);
+        return ResponseModel.createResponse(moimSessionResponseDto);
     }
 
     /*

--- a/src/main/java/com/peoplein/moiming/controller/MoimSessionController.java
+++ b/src/main/java/com/peoplein/moiming/controller/MoimSessionController.java
@@ -63,6 +63,12 @@ public class MoimSessionController {
     /*
      정산활동 삭제
      */
+    @DeleteMapping("/{sessionId}")
+    public ResponseModel<String> deleteMoimSession(@PathVariable(name = "sessionId") Long sessionId) {
+        Member curMember = (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        moimSessionService.deleteMoimSession(sessionId, curMember);
+        return ResponseModel.createResponse("OK");
+    }
 
 
     /*

--- a/src/main/java/com/peoplein/moiming/domain/enums/DomainRequestType.java
+++ b/src/main/java/com/peoplein/moiming/domain/enums/DomainRequestType.java
@@ -1,0 +1,8 @@
+package com.peoplein.moiming.domain.enums;
+
+public enum DomainRequestType {
+    CREATE,
+    READ,
+    UPDATE,
+    DELETE
+}

--- a/src/main/java/com/peoplein/moiming/domain/enums/SessionCategoryType.java
+++ b/src/main/java/com/peoplein/moiming/domain/enums/SessionCategoryType.java
@@ -5,6 +5,6 @@ public enum SessionCategoryType {
     ACTIVITY, // 활동
     FOOD, // 음식
     ALCOHOL, // 주류
-    DRINKS, // 음료
+    DRINK, // 음료
     EXTRA
 }

--- a/src/main/java/com/peoplein/moiming/domain/session/MemberSessionLinker.java
+++ b/src/main/java/com/peoplein/moiming/domain/session/MemberSessionLinker.java
@@ -76,4 +76,29 @@ public class MemberSessionLinker {
         return this.getMemberSessionCategoryLinkers().stream().map(mscl -> mscl.getSessionCategory().getCategoryType()).collect(Collectors.toList());
     }
 
+    // 연관관계 편의 메소드
+    public void changeMemberStateSent(Member curMember) {
+        this.memberSessionState = MemberSessionState.SENT;
+        this.updatedAt = LocalDateTime.now();
+
+        // SESSION 정보 변경
+        this.moimSession.addCurCost(singleCost);
+        this.moimSession.addCurSenderCount();
+        this.moimSession.setUpdatedAt(LocalDateTime.now());
+        this.moimSession.setUpdatedUid(curMember.getUid());
+
+    }
+
+    public void changeMemberStateUnsent(Member curMember) {
+        this.memberSessionState = MemberSessionState.UNSENT;
+        this.updatedAt = LocalDateTime.now();
+
+        // SESSION 정보 변경
+        this.moimSession.removalCurCost(singleCost);
+        this.moimSession.removalCurSenderCount();
+        this.moimSession.setUpdatedAt(LocalDateTime.now());
+        this.moimSession.setUpdatedUid(curMember.getUid());
+
+    }
+
 }

--- a/src/main/java/com/peoplein/moiming/domain/session/MemberSessionLinker.java
+++ b/src/main/java/com/peoplein/moiming/domain/session/MemberSessionLinker.java
@@ -48,7 +48,7 @@ public class MemberSessionLinker {
      멤버가 해당 정산에 참여해야 하는 정산 Category 들과의 연결자들
      TODO 바로 List<Category> 가 될 수 있는 방법은 ..
      */
-    @OneToMany(mappedBy = "memberSessionLinker", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "memberSessionLinker", cascade = CascadeType.PERSIST)
     private List<MemberSessionCategoryLinker> memberSessionCategoryLinkers = new ArrayList<>();
 
     public static MemberSessionLinker createMemberSessionLinker(int singleCost, MemberSessionState memberSessionState, Member member, MoimSession moimSession) {

--- a/src/main/java/com/peoplein/moiming/domain/session/MemberSessionLinker.java
+++ b/src/main/java/com/peoplein/moiming/domain/session/MemberSessionLinker.java
@@ -78,27 +78,29 @@ public class MemberSessionLinker {
 
     // 연관관계 편의 메소드
     public void changeMemberStateSent(Member curMember) {
-        this.memberSessionState = MemberSessionState.SENT;
-        this.updatedAt = LocalDateTime.now();
+        if (this.memberSessionState.equals(MemberSessionState.UNSENT)) { // UNSENT → SENT 요청일 경우에만 VALID
+            this.memberSessionState = MemberSessionState.SENT;
+            this.updatedAt = LocalDateTime.now();
 
-        // SESSION 정보 변경
-        this.moimSession.addCurCost(singleCost);
-        this.moimSession.addCurSenderCount();
-        this.moimSession.setUpdatedAt(LocalDateTime.now());
-        this.moimSession.setUpdatedUid(curMember.getUid());
-
+            // SESSION 정보 변경
+            this.moimSession.addCurCost(singleCost);
+            this.moimSession.addCurSenderCount();
+            this.moimSession.setUpdatedAt(LocalDateTime.now());
+            this.moimSession.setUpdatedUid(curMember.getUid());
+        }
     }
 
     public void changeMemberStateUnsent(Member curMember) {
-        this.memberSessionState = MemberSessionState.UNSENT;
-        this.updatedAt = LocalDateTime.now();
+        if (this.memberSessionState.equals(MemberSessionState.SENT)) { // SENT → UNSENT 요청일 경우에만 VALID
+            this.memberSessionState = MemberSessionState.UNSENT;
+            this.updatedAt = LocalDateTime.now();
 
-        // SESSION 정보 변경
-        this.moimSession.removalCurCost(singleCost);
-        this.moimSession.removalCurSenderCount();
-        this.moimSession.setUpdatedAt(LocalDateTime.now());
-        this.moimSession.setUpdatedUid(curMember.getUid());
-
+            // SESSION 정보 변경
+            this.moimSession.removalCurCost(singleCost);
+            this.moimSession.removalCurSenderCount();
+            this.moimSession.setUpdatedAt(LocalDateTime.now());
+            this.moimSession.setUpdatedUid(curMember.getUid());
+        }
     }
 
 }

--- a/src/main/java/com/peoplein/moiming/domain/session/MoimSession.java
+++ b/src/main/java/com/peoplein/moiming/domain/session/MoimSession.java
@@ -34,6 +34,8 @@ public class MoimSession {
 
     private int curSenderCount;
 
+    private boolean isFinished;
+
     private LocalDateTime createdAt;
     private String createdUid;
 
@@ -87,6 +89,7 @@ public class MoimSession {
         this.createdUid = createdUid;
 
         // 초기화
+        this.isFinished = false;
         this.curCost = 0;
         this.curSenderCount = 0;
         this.createdAt = LocalDateTime.now();
@@ -102,12 +105,31 @@ public class MoimSession {
         this.createdAt = createdAt;
     }
 
-    public void setCurCost(int curCost) {
-        this.curCost = curCost;
+    public void addCurCost(int sentCost) {
+        this.curCost += sentCost;
+        if (this.curCost == this.totalCost) {
+            //  정산완료
+            this.isFinished = true;
+        }
     }
 
-    public void setCurSenderCount(int curSenderCount) {
-        this.curSenderCount = curSenderCount;
+    public void addCurSenderCount() {
+        this.curSenderCount += 1;
+    }
+
+    // 보냈던걸 취소할 경우
+    public void removalCurCost(int removalCurCost) {
+        if (curCost - removalCurCost < 0) {
+            throw new RuntimeException("계산이 맞지 않습니다 (curCost < 0)");
+        }
+        this.curCost -= removalCurCost;
+    }
+
+    public void removalCurSenderCount() {
+        if (this.curSenderCount == 0) {
+            throw new RuntimeException("인원이 맞지 않습니다 (curSenderCount < 0)");
+        }
+        this.curSenderCount -= 1;
     }
 
     public void setUpdatedAt(LocalDateTime updatedAt) {

--- a/src/main/java/com/peoplein/moiming/domain/session/MoimSession.java
+++ b/src/main/java/com/peoplein/moiming/domain/session/MoimSession.java
@@ -55,10 +55,10 @@ public class MoimSession {
     /*
      다대다 연관관계 매핑
      */
-    @OneToMany(mappedBy = "moimSession", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "moimSession", cascade = CascadeType.PERSIST)
     private List<SessionCategoryItem> sessionCategoryItems = new ArrayList<>();
 
-    @OneToMany(mappedBy = "moimSession", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "moimSession", cascade = CascadeType.PERSIST)
     private List<MemberSessionLinker> memberSessionLinkers = new ArrayList<>();
 
 
@@ -97,4 +97,24 @@ public class MoimSession {
     }
 
 
+    public void changeCreatedAt(LocalDateTime createdAt) {
+        DomainChecker.checkWrongObjectParams(getClass().getName(), createdAt);
+        this.createdAt = createdAt;
+    }
+
+    public void setCurCost(int curCost) {
+        this.curCost = curCost;
+    }
+
+    public void setCurSenderCount(int curSenderCount) {
+        this.curSenderCount = curSenderCount;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    public void setUpdatedUid(String updatedUid) {
+        this.updatedUid = updatedUid;
+    }
 }

--- a/src/main/java/com/peoplein/moiming/model/dto/SessionCategoryDetailsDto.java
+++ b/src/main/java/com/peoplein/moiming/model/dto/SessionCategoryDetailsDto.java
@@ -11,12 +11,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SessionCategoryDetailsDto {
 
     private SessionCategoryType sessionCategoryType;
-    private int categoryTotalCost; // 요청시 정합성 검증용, 따로 저장 및 응답 X
     private List<SessionCategoryItemDto> sessionCategoryItems = new ArrayList<>();
 
     /*

--- a/src/main/java/com/peoplein/moiming/model/dto/domain/MemberSessionLinkerDto.java
+++ b/src/main/java/com/peoplein/moiming/model/dto/domain/MemberSessionLinkerDto.java
@@ -1,33 +1,47 @@
 package com.peoplein.moiming.model.dto.domain;
 
+import com.peoplein.moiming.domain.enums.MemberSessionState;
 import com.peoplein.moiming.domain.enums.SessionCategoryType;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberSessionLinkerDto {
 
     private Long memberId;
     private int singleCost;
+
     private List<SessionCategoryType> sessionCategoryTypes = new ArrayList<>();
 
     // MEMO:: 생성 요청시에는 없음, 전송시 필요 정보
+    private MemberSessionState memberSessionState;
     private MoimMemberInfoDto moimMemberInfoDto;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
 
     /*
      Constructor -1
      응답용 Dto 형성시 필요 정보들을 토대로 Dto 형성
      */
-    public MemberSessionLinkerDto(Long memberId, int singleCost, List<SessionCategoryType> sessionCategoryTypes, MoimMemberInfoDto moimMemberInfoDto) {
+    public MemberSessionLinkerDto(Long memberId, int singleCost, List<SessionCategoryType> sessionCategoryTypes, MoimMemberInfoDto moimMemberInfoDto
+    , MemberSessionState memberSessionState, LocalDateTime createdAt, LocalDateTime updatedAt) {
 
         this.memberId = memberId;
         this.singleCost = singleCost;
         this.sessionCategoryTypes = sessionCategoryTypes;
         this.moimMemberInfoDto = moimMemberInfoDto;
+
+        this.memberSessionState = memberSessionState;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+
     }
 
 }

--- a/src/main/java/com/peoplein/moiming/model/dto/domain/MoimSessionDto.java
+++ b/src/main/java/com/peoplein/moiming/model/dto/domain/MoimSessionDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -36,6 +37,13 @@ public class MoimSessionDto {
      MoimSession 도메인 정보를 가지고 DTO 를 만들어내는 Constructor
      */
     public MoimSessionDto(MoimSession moimSession) {
+        // ID 만 조회하는 것은 QUERY 에 영향을 주지 않는다
+        // 생성 요청시 NULL
+        this.moimId = moimSession.getMoim().getId();
+        if (!Objects.isNull(moimSession.getSchedule())) { // 없을 수도 있음
+            this.scheduleId = moimSession.getSchedule().getId();
+        }
+        //
         this.sessionId = moimSession.getId();
         this.sessionName = moimSession.getSessionName();
         this.sessionInfo = moimSession.getSessionInfo();

--- a/src/main/java/com/peoplein/moiming/model/dto/domain/MoimSessionDto.java
+++ b/src/main/java/com/peoplein/moiming/model/dto/domain/MoimSessionDto.java
@@ -25,6 +25,7 @@ public class MoimSessionDto {
      생성 요청 시에는 부재인 정보들
      */
     private Long sessionId;
+    private boolean isFinished;
     private int curCost;
     private int curSenderCount;
     private LocalDateTime createdAt;
@@ -55,6 +56,7 @@ public class MoimSessionDto {
         this.createdUid = moimSession.getCreatedUid();
         this.updatedAt = moimSession.getUpdatedAt();
         this.updatedUid = moimSession.getUpdatedUid();
+        this.isFinished = moimSession.isFinished();
     }
 
 //    /*

--- a/src/main/java/com/peoplein/moiming/model/dto/request/MemberSessionStateRequestDto.java
+++ b/src/main/java/com/peoplein/moiming/model/dto/request/MemberSessionStateRequestDto.java
@@ -1,0 +1,14 @@
+package com.peoplein.moiming.model.dto.request;
+
+import com.peoplein.moiming.domain.enums.MemberSessionState;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberSessionStateRequestDto {
+
+    private MemberSessionState memberSessionState;
+
+}

--- a/src/main/java/com/peoplein/moiming/model/dto/request/MoimSessionRequestDto.java
+++ b/src/main/java/com/peoplein/moiming/model/dto/request/MoimSessionRequestDto.java
@@ -17,7 +17,7 @@ public class MoimSessionRequestDto {
     // Session 기본 정보
     private MoimSessionDto moimSessionDto;
 
-    //
+
     // 정산 항목을 받아야 하고 * MoimSessionCategoryLinker
     // 정산 항목 내부에 하위 카테고리로 정산 품목들이 List 로 들어와있어야 한다
     private List<SessionCategoryDetailsDto> sessionCategoryDetailsDtos = new ArrayList<>();

--- a/src/main/java/com/peoplein/moiming/repository/MemberSessionCategoryLinkerRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/MemberSessionCategoryLinkerRepository.java
@@ -1,0 +1,8 @@
+package com.peoplein.moiming.repository;
+
+import java.util.List;
+
+public interface MemberSessionCategoryLinkerRepository {
+
+    void removeAll(List<Long> mslIds);
+}

--- a/src/main/java/com/peoplein/moiming/repository/MemberSessionLinkerRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/MemberSessionLinkerRepository.java
@@ -1,0 +1,10 @@
+package com.peoplein.moiming.repository;
+
+import com.peoplein.moiming.domain.session.MemberSessionLinker;
+
+public interface MemberSessionLinkerRepository {
+
+    Long save(MemberSessionLinker memberSessionLinker);
+
+    void removeAll(Long moimSessionId);
+}

--- a/src/main/java/com/peoplein/moiming/repository/MemberSessionLinkerRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/MemberSessionLinkerRepository.java
@@ -2,9 +2,13 @@ package com.peoplein.moiming.repository;
 
 import com.peoplein.moiming.domain.session.MemberSessionLinker;
 
+import java.util.Optional;
+
 public interface MemberSessionLinkerRepository {
 
     Long save(MemberSessionLinker memberSessionLinker);
+
+    Optional<MemberSessionLinker> findOptionalByMemberAndSessionId(Long memberId, Long sessionId);
 
     void removeAll(Long moimSessionId);
 }

--- a/src/main/java/com/peoplein/moiming/repository/MoimSessionRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/MoimSessionRepository.java
@@ -10,4 +10,5 @@ public interface MoimSessionRepository {
     Long save(MoimSession moimSession);
     Optional<MoimSession> findOptionalById(Long sessionId);
     List<MoimSession> findAllByMoimId(Long moimId);
+    void remove(MoimSession moimSession);
 }

--- a/src/main/java/com/peoplein/moiming/repository/SessionCategoryItemRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/SessionCategoryItemRepository.java
@@ -1,0 +1,10 @@
+package com.peoplein.moiming.repository;
+
+import com.peoplein.moiming.domain.session.SessionCategoryItem;
+
+public interface SessionCategoryItemRepository {
+
+    Long save(SessionCategoryItem sessionCategoryItem);
+
+    void removeAll(Long moimSessionId);
+}

--- a/src/main/java/com/peoplein/moiming/repository/jpa/MemberSessionCategoryLinkerJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/MemberSessionCategoryLinkerJpaRepository.java
@@ -1,0 +1,27 @@
+package com.peoplein.moiming.repository.jpa;
+
+import com.peoplein.moiming.repository.MemberSessionCategoryLinkerRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static com.peoplein.moiming.domain.session.QMemberSessionLinker.memberSessionLinker;
+import static com.peoplein.moiming.domain.session.QMemberSessionCategoryLinker.*;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberSessionCategoryLinkerJpaRepository implements MemberSessionCategoryLinkerRepository {
+
+    private final EntityManager em;
+    private final JPAQueryFactory queryFactory;
+
+
+    @Override
+    public void removeAll(List<Long> memberSessionLinkerIds) {
+        queryFactory.delete(memberSessionCategoryLinker)
+                .where(memberSessionCategoryLinker.memberSessionLinker.id.in(memberSessionLinkerIds)).execute();
+    }
+}

--- a/src/main/java/com/peoplein/moiming/repository/jpa/MemberSessionLinkerJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/MemberSessionLinkerJpaRepository.java
@@ -13,8 +13,8 @@ import static com.peoplein.moiming.domain.session.QMemberSessionLinker.*;
 @RequiredArgsConstructor
 public class MemberSessionLinkerJpaRepository implements MemberSessionLinkerRepository {
 
-    private EntityManager em;
-    private JPAQueryFactory queryFactory;
+    private final EntityManager em;
+    private final JPAQueryFactory queryFactory;
 
     @Override
     public Long save(MemberSessionLinker memberSessionLinker) {

--- a/src/main/java/com/peoplein/moiming/repository/jpa/MemberSessionLinkerJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/MemberSessionLinkerJpaRepository.java
@@ -8,7 +8,11 @@ import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
 
+import java.util.Optional;
+
 import static com.peoplein.moiming.domain.session.QMemberSessionLinker.*;
+import static com.peoplein.moiming.domain.session.QMoimSession.*;
+
 @Repository
 @RequiredArgsConstructor
 public class MemberSessionLinkerJpaRepository implements MemberSessionLinkerRepository {
@@ -20,6 +24,16 @@ public class MemberSessionLinkerJpaRepository implements MemberSessionLinkerRepo
     public Long save(MemberSessionLinker memberSessionLinker) {
         em.persist(memberSessionLinker);
         return memberSessionLinker.getId();
+    }
+
+    @Override
+    public Optional<MemberSessionLinker> findOptionalByMemberAndSessionId(Long memberId, Long sessionId) {
+
+        return Optional.ofNullable(queryFactory.selectFrom(memberSessionLinker)
+                .join(memberSessionLinker.moimSession, moimSession).fetchJoin()
+                .where(memberSessionLinker.member.id.eq(memberId)
+                        , memberSessionLinker.moimSession.id.eq(sessionId))
+                .fetchOne());
     }
 
     @Override

--- a/src/main/java/com/peoplein/moiming/repository/jpa/MemberSessionLinkerJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/MemberSessionLinkerJpaRepository.java
@@ -1,0 +1,29 @@
+package com.peoplein.moiming.repository.jpa;
+
+import com.peoplein.moiming.domain.session.MemberSessionLinker;
+import com.peoplein.moiming.repository.MemberSessionLinkerRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+
+import static com.peoplein.moiming.domain.session.QMemberSessionLinker.*;
+@Repository
+@RequiredArgsConstructor
+public class MemberSessionLinkerJpaRepository implements MemberSessionLinkerRepository {
+
+    private EntityManager em;
+    private JPAQueryFactory queryFactory;
+
+    @Override
+    public Long save(MemberSessionLinker memberSessionLinker) {
+        em.persist(memberSessionLinker);
+        return memberSessionLinker.getId();
+    }
+
+    @Override
+    public void removeAll(Long moimSessionId) {
+        queryFactory.delete(memberSessionLinker).where(memberSessionLinker.moimSession.id.eq(moimSessionId)).execute();
+    }
+}

--- a/src/main/java/com/peoplein/moiming/repository/jpa/MoimSessionJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/MoimSessionJpaRepository.java
@@ -41,4 +41,9 @@ public class MoimSessionJpaRepository implements MoimSessionRepository {
                 .where(moimSession.moim.id.eq(moimId))
                 .fetch();
     }
+
+    @Override
+    public void remove(MoimSession moimSession) {
+        em.remove(moimSession);
+    }
 }

--- a/src/main/java/com/peoplein/moiming/repository/jpa/MoimSessionJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/MoimSessionJpaRepository.java
@@ -27,10 +27,12 @@ public class MoimSessionJpaRepository implements MoimSessionRepository {
         return moimSession.getId();
     }
 
+    // Schedule Join 된 상태로 조회하면, Schedule 이 없을시 조회되지 않는다
+    // session 에 schedule 이 있을 때 조회하는걸로 하자
     @Override
     public Optional<MoimSession> findOptionalById(Long sessionId) {
         return Optional.ofNullable(queryFactory.selectFrom(moimSession)
-                .join(moimSession.schedule, schedule).fetchJoin()
+//                .join(moimSession.schedule, schedule).fetchJoin()
                 .where(moimSession.id.eq(sessionId))
                 .fetchOne());
     }

--- a/src/main/java/com/peoplein/moiming/repository/jpa/MoimSessionJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/MoimSessionJpaRepository.java
@@ -27,12 +27,10 @@ public class MoimSessionJpaRepository implements MoimSessionRepository {
         return moimSession.getId();
     }
 
-    // Schedule Join 된 상태로 조회하면, Schedule 이 없을시 조회되지 않는다
-    // session 에 schedule 이 있을 때 조회하는걸로 하자
     @Override
     public Optional<MoimSession> findOptionalById(Long sessionId) {
         return Optional.ofNullable(queryFactory.selectFrom(moimSession)
-//                .join(moimSession.schedule, schedule).fetchJoin()
+                .innerJoin(moimSession.schedule, schedule).fetchJoin()
                 .where(moimSession.id.eq(sessionId))
                 .fetchOne());
     }

--- a/src/main/java/com/peoplein/moiming/repository/jpa/SessionCategoryItemJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/SessionCategoryItemJpaRepository.java
@@ -1,0 +1,29 @@
+package com.peoplein.moiming.repository.jpa;
+
+import com.peoplein.moiming.domain.session.SessionCategoryItem;
+import com.peoplein.moiming.repository.SessionCategoryItemRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+
+import static com.peoplein.moiming.domain.session.QSessionCategoryItem.*;
+@Repository
+@RequiredArgsConstructor
+public class SessionCategoryItemJpaRepository implements SessionCategoryItemRepository {
+
+    private EntityManager em;
+    private JPAQueryFactory queryFactory;
+
+    @Override
+    public Long save(SessionCategoryItem sessionCategoryItem) {
+        em.persist(sessionCategoryItem);
+        return sessionCategoryItem.getId();
+    }
+
+    @Override
+    public void removeAll(Long moimSessionId) {
+        queryFactory.delete(sessionCategoryItem).where(sessionCategoryItem.moimSession.id.eq(moimSessionId)).execute();
+    }
+}

--- a/src/main/java/com/peoplein/moiming/repository/jpa/SessionCategoryItemJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/SessionCategoryItemJpaRepository.java
@@ -13,8 +13,8 @@ import static com.peoplein.moiming.domain.session.QSessionCategoryItem.*;
 @RequiredArgsConstructor
 public class SessionCategoryItemJpaRepository implements SessionCategoryItemRepository {
 
-    private EntityManager em;
-    private JPAQueryFactory queryFactory;
+    private final EntityManager em;
+    private final JPAQueryFactory queryFactory;
 
     @Override
     public Long save(SessionCategoryItem sessionCategoryItem) {

--- a/src/main/java/com/peoplein/moiming/service/MoimSessionService.java
+++ b/src/main/java/com/peoplein/moiming/service/MoimSessionService.java
@@ -30,6 +30,9 @@ public class MoimSessionService {
 
     public MoimSessionResponseDto createMoimSession(MoimSessionRequestDto moimSessionRequestDto, Member curMember) {
 
+        // 생성 자체는 일반 유저가 불가능
+        moimSessionServiceShell.checkAuthority("CREATE", moimSessionRequestDto.getMoimSessionDto().getMoimId(), curMember);
+
         // moimSessionRequestDto 를 전달하여 Repository 단에서 통신 준비를 마치고, 준비된 애들을 가지고 와준다.
         MoimSessionServiceInput entityInputs = moimSessionServiceShell.createInputForNewMoimSesion(moimSessionRequestDto);
 
@@ -46,7 +49,9 @@ public class MoimSessionService {
                     int costCnt = 0;
 
                     for (SessionCategoryItemDto item : categoryDetails.getSessionCategoryItems()) {
-                        // 전송하는 기본 Data Set 지정 필요 > 그 항목으로 들어올 경우, DEFAUL 로 저장됨
+
+                        // TODO :: 전송하는 기본 Data Set 지정 필요 > 그 항목으로 들어올 경우, DEFAULT 로 저장됨
+
                         String itemName = item.getItemName();
                         if (itemName.equals("기본") || itemName.equals("")) {
                             itemName = SessionCategoryItem.DEFAULT_ITEM_NAME;
@@ -95,6 +100,7 @@ public class MoimSessionService {
          2. MoimSession 을 조회할 수 있도록 한다
          3. MoimSession 들의 기본 정보 형성 및 전달을 위해선?
          */
+
         List<MoimSession> moimSessions = moimSessionServiceShell.getAllMoimSessions(moimId);
         List<MoimSessionDto> moimSessionDtos = new ArrayList<>();
 
@@ -115,6 +121,15 @@ public class MoimSessionService {
 
         // Long sessionId 에 val 이 하나 건너와야 한다
 
+
+    }
+
+    public void deleteMoimSession(Long sessionId, Member curMember) {
+
+        // moimSession 을 삭제하기 위해선 권한 확인
+        MoimSession moimSession = moimSessionServiceShell.getMoimSession(sessionId);
+        moimSessionServiceShell.checkAuthority("UPDATE", moimSession.getMoim().getId(), curMember);
+        moimSessionServiceShell.processDelete(moimSession);
 
     }
 

--- a/src/main/java/com/peoplein/moiming/service/MoimSessionService.java
+++ b/src/main/java/com/peoplein/moiming/service/MoimSessionService.java
@@ -221,18 +221,13 @@ public class MoimSessionService {
 
         // 해당 Linker 에 대한 state 을 변경한다
         // 보냈음을 확인처리
-        if (memberSessionLinker.getMemberSessionState().equals(MemberSessionState.UNSENT)) {
-            if (memberSessionStateRequestDto.getMemberSessionState().equals(MemberSessionState.SENT)) {
-                // 바꿨다고 해주는 경우에는, Session 정보도 업데이트를 해준다
-                memberSessionLinker.changeMemberStateSent(curMember);
-            }
+        if (memberSessionStateRequestDto.getMemberSessionState().equals(MemberSessionState.SENT)) {
+            memberSessionLinker.changeMemberStateSent(curMember);
         }
 
         // 보냈던걸 취소처리
-        if (memberSessionLinker.getMemberSessionState().equals(MemberSessionState.SENT)) {
-            if (memberSessionStateRequestDto.getMemberSessionState().equals(MemberSessionState.UNSENT)) {
-                memberSessionLinker.changeMemberStateUnsent(curMember);
-            }
+        if (memberSessionStateRequestDto.getMemberSessionState().equals(MemberSessionState.UNSENT)) {
+            memberSessionLinker.changeMemberStateUnsent(curMember);
         }
 
         List<SessionCategoryType> categoryTypes = changeSessionCategoryLinkerToType(memberSessionLinker);

--- a/src/main/java/com/peoplein/moiming/service/MoimSessionService.java
+++ b/src/main/java/com/peoplein/moiming/service/MoimSessionService.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -65,8 +66,6 @@ public class MoimSessionService {
 
                         costCnt += item.getItemCost();
                     }
-
-                    if (categoryDetails.getCategoryTotalCost() != costCnt) throw new RuntimeException("카테고리 정산이 일치하지 않습니다");
                 }
         );
 
@@ -90,7 +89,7 @@ public class MoimSessionService {
         // DB 에 푸시 후 RETURN Model 준비
         moimSessionServiceShell.saveMoimSession(moimSession);
 
-        return moimSessionServiceShell.buildAllResponseModel(moimSession, curMember);
+        return moimSessionServiceShell.buildAllResponseModel(moimSession);
     }
 
     public List<MoimSessionDto> getAllMoimSessions(Long moimId, Member curMember) {
@@ -114,28 +113,105 @@ public class MoimSessionService {
     public MoimSessionResponseDto getMoimSession(Long moimSessionId, Member curMember) {
         // MoimSession 을 가지고 와서 ResponseModel 을 만든다
         MoimSession moimSession = moimSessionServiceShell.getMoimSession(moimSessionId);
-        return moimSessionServiceShell.buildAllResponseModel(moimSession, curMember);
+        return moimSessionServiceShell.buildAllResponseModel(moimSession);
     }
 
-    public MoimSessionResponseDto updateMoimSession(MoimSessionRequestDto moimSessionRequestDto, Member curMember) {
+    // TODO :: 생각해볼 사항
+    //         정산활동 같은 경우 여러 도메인들이 엮여 있음
+    //         가령, 특정한 Category 내 CategoryItem 이 완전히 바뀌는 것을 "수정"이라고 해보면,
+    //         거의 새로운 정산활동을 만들어줘야 하는 것 > 수정의 요소를 판단하기 어려움
+    //         또한, 금액 수정도 서로 연관이 되어 있음. 하나만 바꿔줘도, 다 바꿔줘야 할 수도 있음
+    //         수정이 꽤나 복잡한 로직을 탈 수 있을 것으로 보임
+    //         일단 들어온 것 삭제 후, 재생성 로직 진행하는 것으로 구현해 두었다.
 
-        // Long sessionId 에 val 이 하나 건너와야 한다
+    //         정산활동이 시작된 이후 (보낸사람이 존재하기 시작) 로는 수정이 불가능하다, 따라서, curCost, curSenderCnt 를 안바꿔줘도 된다
+    //         즉, PATCH 가 아닌 PUT이 맞음. > 수정 데이터 외의 모든 데이터를 그대로 보내줘야 함
+
+    public MoimSessionResponseDto updateMoimSession(MoimSessionRequestDto moimSessionRequestDto, Member updateRequestMember) {
+
+        // created 정보는 멤버 매핑도 아니고, uid 와 at 이므로 기존 정보 이어간다\
         MoimSession moimSession = moimSessionServiceShell.getMoimSession(moimSessionRequestDto.getMoimSessionDto().getSessionId());
-        moimSessionServiceShell.checkAuthority("UPDATE", moimSession.getMoim().getId(), curMember);
+        moimSessionServiceShell.checkAuthority("UPDATE", moimSession.getMoim().getId(), updateRequestMember);
 
+        // 삭제하기에 앞서, 필요한 정보들은 선추출한다
+        LocalDateTime preCreatedAt = moimSession.getCreatedAt();
+        String preCreatedUid = moimSession.getCreatedUid();
 
-        // TODO :: 생각해볼 사항
-        //         정산활동 같은 경우 여러 도메인들이 엮여 있음
-        //         가령, 특정한 Category 내 CategoryItem 이 완전히 바뀌는 것을 "수정"이라고 해보면,
-        //         거의 새로운 정산활동을 만들어줘야 하는 것 > 수정의 요소를 판단하기 어려움
-        //         또한, 금액 수정도 서로 연관이 되어 있음. 하나만 바꿔줘도, 다 바꿔줘야 할 수도 있음
-        //         수정이 꽤나 복잡한 로직을 탈 수 있을 것으로 보임
-        //         일단 들어온 것 삭제 후, 재생성 로직 진행하는 것으로 구현해 두었다.
+        // 삭제 진행한다, 권한 SKIP 을 위해, SHELL 직접 호출
+        moimSessionServiceShell.processDelete(moimSession);
 
-        deleteMoimSession(moimSessionRequestDto.getMoimSessionDto().getSessionId(), curMember);
-        return createMoimSession(moimSessionRequestDto, curMember);
+        // DTO 를 통한 생성 진행한다
+        // TODO 위 CREATE 로직과 동일하나, 생성시 UPDATE 용 추가 정보들로 RESET 진행한다
+        MoimSessionServiceInput entityInputs = moimSessionServiceShell.createInputForNewMoimSesion(moimSessionRequestDto);
 
+        MoimSessionDto moimSessionDto = moimSessionRequestDto.getMoimSessionDto();
+
+        MoimSession updatingMoimSession = MoimSession.createMoimSession(
+                moimSessionDto.getSessionName(), moimSessionDto.getSessionInfo()
+                , moimSessionDto.getTotalCost(), moimSessionDto.getTotalSenderCount(), preCreatedUid
+                , entityInputs.getMoimOfNewMoimSession(), entityInputs.getScheduleOfNewMoimSession()
+        );
+
+        moimSessionRequestDto.getSessionCategoryDetailsDtos().forEach(categoryDetails -> {
+                    SessionCategoryType sessionCategoryType = categoryDetails.getSessionCategoryType();
+
+                    int costCnt = 0;
+
+                    for (SessionCategoryItemDto item : categoryDetails.getSessionCategoryItems()) {
+
+                        // TODO :: 전송하는 기본 Data Set 지정 필요 > 그 항목으로 들어올 경우, DEFAULT 로 저장됨
+
+                        String itemName = item.getItemName();
+                        if (itemName.equals("기본") || itemName.equals("")) {
+                            itemName = SessionCategoryItem.DEFAULT_ITEM_NAME;
+                        }
+
+                        // CASCADE 로 moimSession 저장시 자동 저장
+                        SessionCategoryItem sessionCategoryItem = SessionCategoryItem.createSessionCategoryItem(
+                                itemName, item.getItemCost(), updatingMoimSession,
+                                entityInputs.getSessionCategoryByType(sessionCategoryType)
+                        );
+
+                        costCnt += item.getItemCost();
+                    }
+                }
+        );
+
+        moimSessionRequestDto.getMemberSessionLinkerDtos().forEach(memberSessionLinkerDto -> {
+
+            // MoimSession push 시 cascade
+            MemberSessionLinker memberSessionLinker = MemberSessionLinker.createMemberSessionLinker(
+                    memberSessionLinkerDto.getSingleCost(), MemberSessionState.UNSENT
+                    , entityInputs.getMemberById(memberSessionLinkerDto.getMemberId())
+                    , updatingMoimSession
+            );
+
+            // MemberSessionLinker push 시 cascade
+            memberSessionLinkerDto.getSessionCategoryTypes().forEach(categoryType -> {
+                MemberSessionCategoryLinker memberSessionCategoryLinker = new MemberSessionCategoryLinker(
+                        memberSessionLinker, entityInputs.getSessionCategoryByType(categoryType)
+                );
+            });
+        });
+
+        // 초기화 정보 update 적용
+        // 정산활동이 시작된 이후 (보낸사람이 존재하기 시작) 로는 수정이 불가능하다, 따라서, curCost, curSenderCnt 를 안바꿔줘도 된다
+//        moimSession.setCurCost(moimSessionDto.getCurCost());
+//        moimSession.setCurSenderCount(moimSessionDto.getCurSenderCount());
+
+        // 기존 정보 유지
+        updatingMoimSession.changeCreatedAt(preCreatedAt);
+
+        // 업데이트 정보 등록
+        updatingMoimSession.setUpdatedAt(LocalDateTime.now());
+        updatingMoimSession.setUpdatedUid(updateRequestMember.getUid());
+
+        // DB 에 푸시 후 RETURN Model 준비
+        moimSessionServiceShell.saveMoimSession(updatingMoimSession);
+
+        return moimSessionServiceShell.buildAllResponseModel(updatingMoimSession);
     }
+
 
     public void deleteMoimSession(Long sessionId, Member curMember) {
 

--- a/src/main/java/com/peoplein/moiming/service/MoimSessionService.java
+++ b/src/main/java/com/peoplein/moiming/service/MoimSessionService.java
@@ -90,7 +90,7 @@ public class MoimSessionService {
         // DB 에 푸시 후 RETURN Model 준비
         moimSessionServiceShell.saveMoimSession(moimSession);
 
-        return moimSessionServiceShell.buildAllResponeModel(moimSession, curMember);
+        return moimSessionServiceShell.buildAllResponseModel(moimSession, curMember);
     }
 
     public List<MoimSessionDto> getAllMoimSessions(Long moimId, Member curMember) {
@@ -114,13 +114,26 @@ public class MoimSessionService {
     public MoimSessionResponseDto getMoimSession(Long moimSessionId, Member curMember) {
         // MoimSession 을 가지고 와서 ResponseModel 을 만든다
         MoimSession moimSession = moimSessionServiceShell.getMoimSession(moimSessionId);
-        return moimSessionServiceShell.buildAllResponeModel(moimSession, curMember);
+        return moimSessionServiceShell.buildAllResponseModel(moimSession, curMember);
     }
 
-    public void updateMoimSession(MoimSessionRequestDto moimSessionRequestDto, Member curMember) {
+    public MoimSessionResponseDto updateMoimSession(MoimSessionRequestDto moimSessionRequestDto, Member curMember) {
 
         // Long sessionId 에 val 이 하나 건너와야 한다
+        MoimSession moimSession = moimSessionServiceShell.getMoimSession(moimSessionRequestDto.getMoimSessionDto().getSessionId());
+        moimSessionServiceShell.checkAuthority("UPDATE", moimSession.getMoim().getId(), curMember);
 
+
+        // TODO :: 생각해볼 사항
+        //         정산활동 같은 경우 여러 도메인들이 엮여 있음
+        //         가령, 특정한 Category 내 CategoryItem 이 완전히 바뀌는 것을 "수정"이라고 해보면,
+        //         거의 새로운 정산활동을 만들어줘야 하는 것 > 수정의 요소를 판단하기 어려움
+        //         또한, 금액 수정도 서로 연관이 되어 있음. 하나만 바꿔줘도, 다 바꿔줘야 할 수도 있음
+        //         수정이 꽤나 복잡한 로직을 탈 수 있을 것으로 보임
+        //         일단 들어온 것 삭제 후, 재생성 로직 진행하는 것으로 구현해 두었다.
+
+        deleteMoimSession(moimSessionRequestDto.getMoimSessionDto().getSessionId(), curMember);
+        return createMoimSession(moimSessionRequestDto, curMember);
 
     }
 
@@ -128,7 +141,7 @@ public class MoimSessionService {
 
         // moimSession 을 삭제하기 위해선 권한 확인
         MoimSession moimSession = moimSessionServiceShell.getMoimSession(sessionId);
-        moimSessionServiceShell.checkAuthority("UPDATE", moimSession.getMoim().getId(), curMember);
+        moimSessionServiceShell.checkAuthority("DELETE", moimSession.getMoim().getId(), curMember);
         moimSessionServiceShell.processDelete(moimSession);
 
     }

--- a/src/main/java/com/peoplein/moiming/service/shell/MoimSessionServiceShell.java
+++ b/src/main/java/com/peoplein/moiming/service/shell/MoimSessionServiceShell.java
@@ -72,7 +72,7 @@ public class MoimSessionServiceShell {
         return moimSessionRepository.findOptionalById(moimSessionId).orElseThrow(() -> new RuntimeException("해당 MoimSession 을 찾을 수 없습니다"));
     }
 
-    public MoimSessionResponseDto buildAllResponeModel(MoimSession moimSession
+    public MoimSessionResponseDto buildAllResponseModel(MoimSession moimSession
             , Member curMember) {
 
         // MoimSession 정보를 기준으로 다 만들어낸다

--- a/src/main/java/com/peoplein/moiming/service/shell/MoimSessionServiceShell.java
+++ b/src/main/java/com/peoplein/moiming/service/shell/MoimSessionServiceShell.java
@@ -140,7 +140,9 @@ public class MoimSessionServiceShell {
                     memberSessionLinker.getMember().getId(), memberSessionLinker.getSingleCost()
                     , memberSessionLinker.getMemberSessionCategoryTypes()
                     , moimMemberInfoDto
+                    , memberSessionLinker.getMemberSessionState(), memberSessionLinker.getCreatedAt(), memberSessionLinker.getUpdatedAt()
             );
+
             memberSessionLinkerDtos.add(memberSessionLinkerDto);
         });
 
@@ -151,12 +153,13 @@ public class MoimSessionServiceShell {
     }
 
     // 정산활동 관리는 오직 리더나 관리자
-    public void checkAuthority(String path, Long moimId, Member curMember) {
+    public MemberMoimLinker checkAuthority(String path, Long moimId, Member curMember) {
         MemberMoimLinker mml = memberMoimLinkerRepository.findByMemberAndMoimId(curMember.getId(), moimId);
         if (!mml.getMoimRoleType().equals(MoimRoleType.MANAGER) && !mml.getMoimRoleType().equals(MoimRoleType.LEADER) &&
                 !mml.getMoimRoleType().equals(MoimRoleType.CREATOR)) {
             throw new RuntimeException("정산활동 관여 권한이 없는 유저입니다");
         }
+        return mml;
     }
 
     public void processDelete(MoimSession moimSession) {
@@ -174,4 +177,20 @@ public class MoimSessionServiceShell {
 
     }
 
+    public MemberMoimLinker findMemberMoimLinker(Long memberId, Long moimId) {
+
+        Optional<MemberMoimLinker> optionalMml = memberMoimLinkerRepository.findOptionalByMemberAndMoimId(memberId, moimId);
+        if (optionalMml.isEmpty()) {
+            throw new RuntimeException("대상 유저는 해당 모임에 속하지 않습니다");
+        }
+        return optionalMml.get();
+    }
+
+    public MemberSessionLinker findMoimSessionLinker(Long sessionId, Long memberId) {
+        Optional<MemberSessionLinker> optionalMsl = memberSessionLinkerRepository.findOptionalByMemberAndSessionId(memberId, sessionId);
+        if (optionalMsl.isEmpty()) {
+            throw new RuntimeException("해당 ID의 MemberSessionLinker 를 찾을 수 없습니다");
+        }
+        return optionalMsl.get();
+    }
 }

--- a/src/main/java/com/peoplein/moiming/service/shell/MoimSessionServiceShell.java
+++ b/src/main/java/com/peoplein/moiming/service/shell/MoimSessionServiceShell.java
@@ -152,7 +152,8 @@ public class MoimSessionServiceShell {
     // 정산활동 관리는 오직 리더나 관리자
     public void checkAuthority(String path, Long moimId, Member curMember) {
         MemberMoimLinker mml = memberMoimLinkerRepository.findByMemberAndMoimId(curMember.getId(), moimId);
-        if (!mml.getMoimRoleType().equals(MoimRoleType.MANAGER) && !mml.getMoimRoleType().equals(MoimRoleType.LEADER)) {
+        if (!mml.getMoimRoleType().equals(MoimRoleType.MANAGER) && !mml.getMoimRoleType().equals(MoimRoleType.LEADER) &&
+                !mml.getMoimRoleType().equals(MoimRoleType.CREATOR)) {
             throw new RuntimeException("정산활동 관여 권한이 없는 유저입니다");
         }
     }

--- a/src/main/resources/session-update-request-body.json
+++ b/src/main/resources/session-update-request-body.json
@@ -1,15 +1,18 @@
 {
   "moimSessionDto": {
+    "sessionId": 93,
     "moimId": 15,
+    "scheduleId": 26,
     "sessionName": "3월 회식 정산",
     "sessionInfo": "1,2차 나눠서 정산합니다",
     "totalCost": 300000,
-    "totalSenderCount": 3
+    "totalSenderCount": 4
   },
+
   "sessionCategoryDetailsDtos": [
     {
       "sessionCategoryType": "ACTIVITY",
-      "categoryTotalCost": 150000,
+      "categoryTotalCost": 160000,
       "sessionCategoryItems": [
         {
           "itemName": "룸대여",
@@ -17,7 +20,7 @@
         },
         {
           "itemName": "",
-          "itemCost": "50000"
+          "itemCost": "60000"
         }
       ]
     },
@@ -37,11 +40,11 @@
     },
     {
       "sessionCategoryType": "ALCOHOL",
-      "categoryTotalCost": 30000,
+      "categoryTotalCost": 20000,
       "sessionCategoryItems": [
         {
           "itemName": "소주값",
-          "itemCost": "30000"
+          "itemCost": "20000"
         }
       ]
     },
@@ -77,7 +80,7 @@
   "memberSessionLinkerDtos": [
     {
       "memberId": 1,
-      "singleCost": 99000,
+      "singleCost": 75000,
       "sessionCategoryTypes": [
         "ACTIVITY",
         "FOOD",
@@ -87,7 +90,7 @@
     },
     {
       "memberId": 4,
-      "singleCost": 93000,
+      "singleCost": 75000,
       "sessionCategoryTypes": [
         "ACTIVITY",
         "FOOD",
@@ -97,11 +100,20 @@
     },
     {
       "memberId": 7,
-      "singleCost": 108000,
+      "singleCost": 75000,
       "sessionCategoryTypes": [
         "ACTIVITY",
         "FOOD",
         "DRINK",
+        "EXTRA"
+      ]
+    },
+    {
+      "memberId": 10,
+      "singleCost": 75000,
+      "sessionCategoryTypes": [
+        "ACTIVITY",
+        "FOOD",
         "ALCOHOL",
         "EXTRA"
       ]


### PR DESCRIPTION
<h2>정산활동 삭제, 수정 로직 개발 </h2>

* 삭제 로직 
각 Linker 들 삭제를 위한 Repository, JpaRepository 모두 생성. Cascade 는 PERSIST 로만 사용
> SessionCategory ( 고정값 ) 와 연계된 SesscionCategoryItem 들을 모두 삭제해준다 
> MemberSessionLinker 삭제를 위해 MemberSessionCategoryLinker 들을 모두 삭제해준다 (MSLinker 들의 ID 들로) 
> MoimSession 을 삭제한다

* 수정 로직
> 연계된 데이터들이 많기 때문에, Put 으로 진행한다 (수정전 정산활동을 삭제, 새로운 정산활동을 생성) 
> 삭제로직을 그대로 사용하고, 생성 로직을 참고하여 유사하게 진행, 수정시 변하지 않는 데이터 (createdUid, createdAt) 따로 전달 
                 
</br>
<h2>정산활동 예제 DB 삽입 </h2>

- InitDatabase.java 에 MoimSession Sample DB 를 넣기 위한 로직 추가

- Postman 에 추가적인 Sample DB, 조회 등에 대해서 구현해 놓음

- 생성 요청, 수정 요청시 보내야할 POST 요청의 JSON BODY Format 파일들 첨부 


</br>
</br>
<h2>리펙토링 진행</h2> 

- 중복 코드 클래스화 
