### PR TITLE
회원 Home 개발

### DIFF
--- a/src/main/java/com/peoplein/moiming/domain/BaseEntity.java
+++ b/src/main/java/com/peoplein/moiming/domain/BaseEntity.java
@@ -3,6 +3,7 @@ package com.peoplein.moiming.domain;
 
 import lombok.Data;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
@@ -14,11 +15,11 @@ import java.time.LocalDateTime;
 @Getter
 public class BaseEntity {
 
-    @Column(nullable = false, updatable = true, insertable = true)
+    @Column(nullable = false, updatable = false, insertable = true)
     private LocalDateTime createdAt;
 
 
-    @Column(updatable = true, insertable = false)
+    @Column(updatable = true, insertable = true, nullable = false)
     private LocalDateTime updatedAt;
 
     @PrePersist

--- a/src/main/java/com/peoplein/moiming/repository/MemberScheduleLinkerRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/MemberScheduleLinkerRepository.java
@@ -18,4 +18,6 @@ public interface MemberScheduleLinkerRepository {
 
     void removeAllByScheduleIds(List<Long> scheduleIds);
 
+    List<MemberScheduleLinker> findMemberScheduleLatest5ByMemberId(Long memberId);
+
 }

--- a/src/main/java/com/peoplein/moiming/repository/MoimPostRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/MoimPostRepository.java
@@ -27,4 +27,6 @@ public interface MoimPostRepository {
 
     void removeMoimPostExecute(MoimPost moimPost);
 
+    List<MoimPost> findNoticesLatest3ByMoimIds(List<Long> moimIds);
+
 }

--- a/src/main/java/com/peoplein/moiming/repository/MoimRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/MoimRepository.java
@@ -19,4 +19,6 @@ public interface MoimRepository {
     void remove(Moim moim);
 
     List<Moim> findMoimBySearchCondition(List<String> keywordList, Area area, Category category);
+
+    List<Moim> findAllMoim();
 }

--- a/src/main/java/com/peoplein/moiming/repository/ScheduleRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/ScheduleRepository.java
@@ -2,6 +2,7 @@ package com.peoplein.moiming.repository;
 
 import com.peoplein.moiming.domain.MoimPost;
 import com.peoplein.moiming.domain.Schedule;
+import com.querydsl.core.Tuple;
 
 import java.util.List;
 import java.util.Optional;
@@ -24,4 +25,5 @@ public interface ScheduleRepository {
 
     void remove(Schedule schedule);
 
+    List<Schedule> findAllSchedule();
 }

--- a/src/main/java/com/peoplein/moiming/repository/jpa/MemberScheduleLinkerJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/MemberScheduleLinkerJpaRepository.java
@@ -57,4 +57,14 @@ public class MemberScheduleLinkerJpaRepository implements MemberScheduleLinkerRe
     public void removeAllByScheduleIds(List<Long> scheduleIds) {
         queryFactory.delete(memberScheduleLinker).where(memberScheduleLinker.schedule.id.in(scheduleIds)).execute();
     }
+
+    @Override
+    public List<MemberScheduleLinker> findMemberScheduleLatest5ByMemberId(Long memberId) {
+        return queryFactory
+                .selectFrom(memberScheduleLinker)
+                .where(memberScheduleLinker.member.id.eq(memberId))
+                .orderBy(memberScheduleLinker.schedule.scheduleDate.desc())
+                .limit(5)
+                .fetch();
+    }
 }

--- a/src/main/java/com/peoplein/moiming/repository/jpa/MoimJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/MoimJpaRepository.java
@@ -85,6 +85,13 @@ public class MoimJpaRepository implements MoimRepository {
         return query.fetch();
     }
 
+    @Override
+    public List<Moim> findAllMoim() {
+        return queryFactory
+                .selectFrom(moim)
+                .fetch();
+    }
+
     private void addJoinQuery(JPAQuery<Moim> query, Category category) {
         if (category == null)
             return;

--- a/src/main/java/com/peoplein/moiming/repository/jpa/MoimPostJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/MoimPostJpaRepository.java
@@ -3,6 +3,7 @@ package com.peoplein.moiming.repository.jpa;
 import com.peoplein.moiming.domain.MoimPost;
 import com.peoplein.moiming.repository.MoimPostRepository;
 import com.peoplein.moiming.repository.PostFileRepository;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -115,6 +116,15 @@ public class MoimPostJpaRepository implements MoimPostRepository {
                 .join(moimPost.member, member).fetchJoin()
                 .join(member.memberInfo, memberInfo).fetchJoin()
                 .where(moimPost.moim.id.eq(moimId))
+                .fetch();
+    }
+
+    @Override
+    public List<MoimPost> findNoticesLatest3ByMoimIds(List<Long> moimIds) {
+        return queryFactory.selectFrom(moimPost)
+                .where(moimPost.moim.id.in(moimIds).and(moimPost.isNotice.eq(true)))
+                .orderBy(moimPost.updatedAt.desc())
+                .limit(3)
                 .fetch();
     }
 

--- a/src/main/java/com/peoplein/moiming/repository/jpa/ScheduleJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/ScheduleJpaRepository.java
@@ -84,5 +84,10 @@ public class ScheduleJpaRepository implements ScheduleRepository {
         em.remove(schedule);
     }
 
+    @Override
+    public List<Schedule> findAllSchedule() {
+        return queryFactory.selectFrom(schedule)
+                .fetch();
+    }
 
 }

--- a/src/main/java/com/peoplein/moiming/service/MemberService.java
+++ b/src/main/java/com/peoplein/moiming/service/MemberService.java
@@ -11,7 +11,6 @@ import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
-@RequiredArgsConstructor
 @Transactional
 @Service
 public class MemberService {
@@ -21,6 +20,18 @@ public class MemberService {
     private final MemberScheduleLinkerRepository memberScheduleLinkerRepository;
     private final MoimRepository moimRepository;
     private final ScheduleRepository scheduleRepository;
+
+    public MemberService(MemberMoimLinkerRepository memberMoimLinkerRepository,
+                         MoimPostRepository moimPostRepository,
+                         MemberScheduleLinkerRepository memberScheduleLinkerRepository,
+                         MoimRepository moimRepository,
+                         ScheduleRepository scheduleRepository) {
+        this.memberMoimLinkerRepository = memberMoimLinkerRepository;
+        this.moimPostRepository = moimPostRepository;
+        this.memberScheduleLinkerRepository = memberScheduleLinkerRepository;
+        this.moimRepository = moimRepository;
+        this.scheduleRepository = scheduleRepository;
+    }
 
 
     // TODO : MemberSchdule은 Attended 일 때만 가져오는지?
@@ -103,12 +114,7 @@ public class MemberService {
 
         private Schedule decideValue(Schedule value) {
             Moim key = value.getMoim();
-
-            if (isFirstData(key)) {
-                return value;
-            } else {
-                return getLatestSchedule(value);
-            }
+            return isFirstData(key) ? value : getLatestSchedule(value);
         }
 
         private Schedule getLatestSchedule(Schedule value) {

--- a/src/main/java/com/peoplein/moiming/service/MemberService.java
+++ b/src/main/java/com/peoplein/moiming/service/MemberService.java
@@ -1,13 +1,121 @@
 package com.peoplein.moiming.service;
 
-import com.peoplein.moiming.repository.MemberRepository;
+import com.peoplein.moiming.domain.*;
+import com.peoplein.moiming.repository.*;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Transactional
+@Service
 public class MemberService {
 
-    private final MemberRepository memberRepository;
+    private final MemberMoimLinkerRepository memberMoimLinkerRepository;
+    private final MoimPostRepository moimPostRepository;
+    private final MemberScheduleLinkerRepository memberScheduleLinkerRepository;
+    private final MoimRepository moimRepository;
+    private final ScheduleRepository scheduleRepository;
 
+
+    // TODO : MemberSchdule은 Attended 일 때만 가져오는지?
+    // TODO : 회비 납부 일정 업데이트 필요.
+
+    /**
+     * 모임 리스트 : 갱신 시마다 랜덤으로 노출 → 여러 개 전달해야 함.
+     * 모임 카드 : 회원수, 가장 빠른 정모일정 및 정모명 노출.
+     * 전달받은 객체를 Controller에서 Front가 원하는 형태로 변경 필요함.
+     */
+    public MemberHomeDto serviceHome(Member curMember) {
+
+        List<MoimPost> findNotices = getMoimNoticesLatestTop3(curMember);
+        List<MemberScheduleLinker> findSchedules = memberScheduleLinkerRepository.findMemberScheduleLatest5ByMemberId(curMember.getId());
+
+        List<Moim> allMoim = moimRepository.findAllMoim();
+        List<Schedule> allSchedule = scheduleRepository.findAllSchedule();
+        MoimScheduleDto moimScheduleDto = new MoimScheduleDto(allMoim, allSchedule);
+
+        return new MemberHomeDto(findSchedules, findNotices, moimScheduleDto);
+    }
+
+    private List<MoimPost> getMoimNoticesLatestTop3(Member curMember) {
+        List<MemberMoimLinker> findMemberMoimLinkers = memberMoimLinkerRepository.findByMemberId(curMember.getId());
+        List<Long> uniqueMoimIds = getUniqueMoimIds(findMemberMoimLinkers);
+        return moimPostRepository.findNoticesLatest3ByMoimIds(uniqueMoimIds);
+    }
+
+    private List<Long> getUniqueMoimIds(List<MemberMoimLinker> findMemberMoimLinkers) {
+        return findMemberMoimLinkers.stream()
+                .map(memberMoimLinker -> memberMoimLinker.getMoim().getId())
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    // 추후 필요한 정보로 수정 필요함.
+    // 정산 필드 추가 필요함. 필요한 경우 아래 필드도 수정해야함. (엔티티 그대로 노출하기 때문)
+    @Getter
+    public static final class MemberHomeDto {
+        private final List<MemberScheduleLinker> memberSchedule;
+        private final List<MoimPost> moimNotices;
+        private final MoimScheduleDto moimScheduleDto;
+
+        public MemberHomeDto(List<MemberScheduleLinker> memberSchedule,
+                             List<MoimPost> moimNotices,
+                             MoimScheduleDto moimScheduleDto) {
+            this.memberSchedule = memberSchedule;
+            this.moimNotices = moimNotices;
+            this.moimScheduleDto = moimScheduleDto;
+        }
+    }
+
+    @Getter
+    public static final class MoimScheduleDto {
+
+        private final Map<Moim, Schedule> moimScheduleMap = new HashMap<>();
+
+        public MoimScheduleDto(List<Moim> moims, List<Schedule> schedules) {
+            initKeyByExistedMoim(moims);
+            updateScheduleByCreatedTime(schedules);
+        }
+
+        private void initKeyByExistedMoim(List<Moim> moims) {
+            moims.forEach(moim -> moimScheduleMap.put(moim, null));
+        }
+
+        private void updateScheduleByCreatedTime(List<Schedule> schedules) {
+            schedules.stream()
+                    .filter(value -> !isNotExistMoim(value.getMoim()))
+                    .forEach(value -> moimScheduleMap.put(value.getMoim(), decideValue(value)));
+        }
+
+        private boolean isNotExistMoim(Moim key) {
+            return !moimScheduleMap.containsKey(key);
+        }
+
+        private boolean isFirstData(Moim key) {
+            return moimScheduleMap.get(key) == null;
+        }
+
+        private Schedule decideValue(Schedule value) {
+            Moim key = value.getMoim();
+
+            if (isFirstData(key)) {
+                return value;
+            } else {
+                return getLatestSchedule(value);
+            }
+        }
+
+        private Schedule getLatestSchedule(Schedule value) {
+            Moim key = value.getMoim();
+            Schedule oldValue = moimScheduleMap.get(key);
+            return oldValue.getScheduleDate().isAfter(value.getScheduleDate()) ?
+                    oldValue : value;
+        }
+    }
 }

--- a/src/main/java/com/peoplein/moiming/service/MoimMemberService.java
+++ b/src/main/java/com/peoplein/moiming/service/MoimMemberService.java
@@ -44,21 +44,9 @@ public class MoimMemberService {
      모임 내 모든 회원 및 상태 조회
      */
     public List<MoimMemberInfoDto> viewMoimMember(Long moimId, Member curMember) {
-
         List<MemberMoimLinker> memberMoimLinkers = memberMoimLinkerRepository.findWithMemberInfoAndMoimByMoimId(moimId);
-        List<MoimMemberInfoDto> moimMemberInfoDto = new ArrayList<>();
-        memberMoimLinkers.forEach(mml -> {
-            moimMemberInfoDto.add(new MoimMemberInfoDto(
-                    mml.getMember().getId(), mml.getMember().getUid()
-                    , mml.getMember().getMemberInfo().getMemberName(), mml.getMember().getMemberInfo().getMemberEmail()
-                    , mml.getMember().getMemberInfo().getMemberGender(), mml.getMember().getMemberInfo().getMemberPfImg()
-                    , mml.getMoimRoleType(), mml.getMemberState()
-                    , mml.getCreatedAt(), mml.getUpdatedAt()
-            ));
-        });
-        return moimMemberInfoDto;
+        return getMoimMemberInfos(memberMoimLinkers);
     }
-
     /**
      * 특정 유저의 모임 가입 요청을 처리한다
      * @param moimJoinRequestDto : Moim 가입 요청 관련 데이터
@@ -103,12 +91,12 @@ public class MoimMemberService {
     /*
      WAIT 상태인 유저의 요청을 처리한다
      */
+
     public MemberMoimLinker decideJoin(MoimMemberActionRequestDto moimMemberActionRequestDto) {
         MemberMoimLinker memberMoimLinker = memberMoimLinkerRepository.findWithMemberInfoByMemberAndMoimId(moimMemberActionRequestDto.getMemberId(), moimMemberActionRequestDto.getMoimId());
         memberMoimLinker.judgeJoin(moimMemberActionRequestDto.getStateAction());
         return memberMoimLinker;
     }
-
     public MoimMemberInfoDto exitMoim(MoimMemberActionRequestDto moimMemberActionRequestDto, Member curMember) {
 
         // 영속화
@@ -176,5 +164,11 @@ public class MoimMemberService {
 
         // 그 Member 의 MoimMemberInfo 를 전달
         return MoimMemberInfoDto.createMemberInfoDto(memberMoimLinker);
+    }
+
+    private List<MoimMemberInfoDto> getMoimMemberInfos(List<MemberMoimLinker> memberMoimLinkers) {
+        return memberMoimLinkers.stream()
+                .map(MoimMemberInfoDto::new)
+                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/com/peoplein/moiming/TestUtils.java
+++ b/src/test/java/com/peoplein/moiming/TestUtils.java
@@ -89,6 +89,8 @@ public class TestUtils {
     public static boolean DUPLICATED_MANAGER_ENABLE = true;
 
 
+    public static final Role role = initAdminRole();
+
 
     public static Member initOtherMemberAndMemberInfo() {
         Role role = initUserRole();
@@ -104,14 +106,20 @@ public class TestUtils {
     }
 
     public static Member initMemberAndMemberInfo() {
-        Role role = initAdminRole();
-
         Member member = Member.createMember(uid, password, memberEmail, memberName, memberGender, role);
         member.getMemberInfo().setMemberBirth(memberBirth);
 
         return member;
-
     }
+
+    public static Member initMemberAndMemberInfo(String memberName, String memberEmail) {
+        Member member = Member.createMember(uid, password, memberEmail, memberName, memberGender, role);
+        member.getMemberInfo().setMemberBirth(memberBirth);
+
+        return member;
+    }
+
+
 
     public static Role initAdminRole() {
         return new Role(1L, "admin", RoleType.ADMIN);
@@ -133,12 +141,20 @@ public class TestUtils {
         return Moim.createMoim(moimName, moimInfo, moimPfImg, new Area(areaState, areaCity), createdUid);
     }
 
+    public static Moim createMoimOnly(String moimName) {
+        return Moim.createMoim(moimName, moimInfo, moimPfImg, new Area(areaState, areaCity), createdUid);
+    }
+
     public static Moim createOtherMoimOnly(String moimName, Area area) {
         return Moim.createMoim(moimName, "other" + moimInfo, "other" + moimPfImg, area, createdUid);
     }
 
     public static MoimPost initMoimPost(Moim moim, Member member) {
         return MoimPost.createMoimPost(postTitle, postContent, moimPostCategory, isNotice, hasFiles, moim, member);
+    }
+
+    public static MoimPost initNoticeMoimPost(Moim moim, Member member) {
+        return MoimPost.createMoimPost(postTitle, postContent, moimPostCategory, true, hasFiles, moim, member);
     }
 
     public static MoimDto initMoimDto() {

--- a/src/test/java/com/peoplein/moiming/TestUtils.java
+++ b/src/test/java/com/peoplein/moiming/TestUtils.java
@@ -119,6 +119,12 @@ public class TestUtils {
         return member;
     }
 
+    public static Member initMemberAndMemberInfo(String uid, String memberName, String memberEmail) {
+        Member member = Member.createMember(uid, password, memberEmail, memberName, memberGender, role);
+        member.getMemberInfo().setMemberBirth(memberBirth);
+
+        return member;
+    }
 
 
     public static Role initAdminRole() {

--- a/src/test/java/com/peoplein/moiming/repository/jpa/MemberScheduleLinkerJpaRepositoryTest.java
+++ b/src/test/java/com/peoplein/moiming/repository/jpa/MemberScheduleLinkerJpaRepositoryTest.java
@@ -1,0 +1,185 @@
+package com.peoplein.moiming.repository.jpa;
+
+import com.peoplein.moiming.BaseTest;
+import com.peoplein.moiming.TestUtils;
+import com.peoplein.moiming.domain.*;
+import com.peoplein.moiming.domain.enums.ScheduleMemberState;
+import com.peoplein.moiming.repository.MemberScheduleLinkerRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@SpringBootTest
+@Transactional
+@Rollback(value = false)
+class MemberScheduleLinkerJpaRepositoryTest extends BaseTest {
+
+    @Autowired
+    EntityManager em;
+
+    @Autowired
+    MemberScheduleLinkerRepository memberScheduleLinkerRepository;
+
+    Member creator;
+    Moim moim1;
+    Moim moim2;
+    Moim moim3;
+
+    Schedule schedule1;
+    Schedule schedule2;
+    Schedule schedule3;
+
+    Schedule schedule4;
+    Schedule schedule5;
+    Schedule schedule6;
+
+    Schedule schedule7;
+    Schedule schedule8;
+
+
+    @BeforeEach
+    void setup() {
+
+        creator = TestUtils.initMemberAndMemberInfo();
+
+        moim1 = TestUtils.createMoimOnly("moim1");
+        moim2 = TestUtils.createMoimOnly("moim2");
+        moim3 = TestUtils.createMoimOnly("moim3");
+
+        schedule1 = Schedule.createSchedule("title1", "location1",
+                LocalDateTime.of(2023, 6, 1, 17, 30), 10,
+                moim1, creator);
+
+        schedule2 = Schedule.createSchedule("title2", "location2",
+                LocalDateTime.of(2023, 6, 1, 18, 30), 10,
+                moim2, creator);
+
+        schedule3 = Schedule.createSchedule("title3", "location3",
+                LocalDateTime.of(2023, 6, 1, 19, 30), 10,
+                moim3, creator);
+
+        schedule4 = Schedule.createSchedule("title3", "location3",
+                LocalDateTime.of(2023, 6, 1, 20, 31), 10,
+                moim3, creator);
+
+        schedule5 = Schedule.createSchedule("title3", "location3",
+                LocalDateTime.of(2023, 6, 1, 20, 32), 10,
+                moim3, creator);
+
+        schedule6 = Schedule.createSchedule("title3", "location3",
+                LocalDateTime.of(2023, 6, 1, 20, 33), 10,
+                moim3, creator);
+
+        schedule7 = Schedule.createSchedule("title3", "location3",
+                LocalDateTime.of(2023, 6, 1, 20, 34), 10,
+                moim3, creator);
+
+        schedule8 = Schedule.createSchedule("title3", "location3",
+                LocalDateTime.of(2023, 6, 1, 20, 35), 10,
+                moim3, creator);
+
+        MemberScheduleLinker linker1 = MemberScheduleLinker.memberJoinSchedule(creator, schedule1, ScheduleMemberState.CREATOR);
+        MemberScheduleLinker linker2 = MemberScheduleLinker.memberJoinSchedule(creator, schedule2, ScheduleMemberState.CREATOR);
+        MemberScheduleLinker linker3 = MemberScheduleLinker.memberJoinSchedule(creator, schedule3, ScheduleMemberState.CREATOR);
+        MemberScheduleLinker linker4 = MemberScheduleLinker.memberJoinSchedule(creator, schedule4, ScheduleMemberState.CREATOR);
+        MemberScheduleLinker linker5 = MemberScheduleLinker.memberJoinSchedule(creator, schedule5, ScheduleMemberState.CREATOR);
+        MemberScheduleLinker linker6 = MemberScheduleLinker.memberJoinSchedule(creator, schedule6, ScheduleMemberState.CREATOR);
+        MemberScheduleLinker linker7 = MemberScheduleLinker.memberJoinSchedule(creator, schedule7, ScheduleMemberState.CREATOR);
+        MemberScheduleLinker linker8 = MemberScheduleLinker.memberJoinSchedule(creator, schedule8, ScheduleMemberState.CREATOR);
+
+
+        persist(creator.getRoles().get(0).getRole(),
+                creator,
+                moim1, moim2, moim3,
+                schedule1, schedule2, schedule3, schedule4, schedule5, schedule6, schedule7, schedule8,
+                linker1, linker2, linker3, linker4, linker5, linker6, linker7, linker8);
+    }
+
+
+    @Test
+    void findMemberScheduleLatest5ByMemberIdSuccessTest1() {
+        // Given :
+        Member member = TestUtils.initMemberAndMemberInfo("attendee", "attendee", "attendee@moiming.net");
+        persist(member);
+
+        // When :
+        List<MemberScheduleLinker> result = memberScheduleLinkerRepository.findMemberScheduleLatest5ByMemberId(member.getId());
+
+        // Then :
+        assertThat(result.size()).isEqualTo(0);
+    }
+
+    @Test
+    void findMemberScheduleLatest5ByMemberIdSuccessTest2() {
+        // Given :
+        Member member = TestUtils.initMemberAndMemberInfo("attendee", "attendee", "attendee@moiming.net");
+
+        MemberScheduleLinker linker1 = MemberScheduleLinker.memberJoinSchedule(member, schedule1, ScheduleMemberState.ATTEND);
+        MemberScheduleLinker linker2 = MemberScheduleLinker.memberJoinSchedule(member, schedule2, ScheduleMemberState.ATTEND);
+        MemberScheduleLinker linker3 = MemberScheduleLinker.memberJoinSchedule(member, schedule3, ScheduleMemberState.ATTEND);
+        MemberScheduleLinker linker4 = MemberScheduleLinker.memberJoinSchedule(member, schedule4, ScheduleMemberState.ATTEND);
+        MemberScheduleLinker linker5 = MemberScheduleLinker.memberJoinSchedule(member, schedule5, ScheduleMemberState.ATTEND);
+        MemberScheduleLinker linker6 = MemberScheduleLinker.memberJoinSchedule(member, schedule6, ScheduleMemberState.NONATTEND);
+        MemberScheduleLinker linker7 = MemberScheduleLinker.memberJoinSchedule(member, schedule7, ScheduleMemberState.NONATTEND);
+        MemberScheduleLinker linker8 = MemberScheduleLinker.memberJoinSchedule(member, schedule8, ScheduleMemberState.NONATTEND);
+
+        persist(member, linker1, linker2, linker3, linker4, linker5, linker6, linker7, linker8);
+
+        // When :
+        List<MemberScheduleLinker> result = memberScheduleLinkerRepository.findMemberScheduleLatest5ByMemberId(member.getId());
+
+        // Then :
+        assertThat(result.size()).isEqualTo(5);
+        assertThat(result).extracting(MemberScheduleLinker::getId)
+                .containsExactly(
+                        linker8.getId(),
+                        linker7.getId(),
+                        linker6.getId(),
+                        linker5.getId(),
+                        linker4.getId());
+    }
+
+    @Test
+    void findMemberScheduleLatest5ByMemberIdSuccessTest3() {
+        // Given :
+        Member member = TestUtils.initMemberAndMemberInfo("attendee", "attendee", "attendee@moiming.net");
+
+        MemberScheduleLinker linker1 = MemberScheduleLinker.memberJoinSchedule(member, schedule1, ScheduleMemberState.ATTEND);
+        MemberScheduleLinker linker2 = MemberScheduleLinker.memberJoinSchedule(member, schedule2, ScheduleMemberState.ATTEND);
+
+        persist(member, linker1, linker2);
+
+        // When :
+        List<MemberScheduleLinker> result = memberScheduleLinkerRepository.findMemberScheduleLatest5ByMemberId(member.getId());
+
+        // Then :
+        assertThat(result.size()).isEqualTo(2);
+        assertThat(result).extracting(MemberScheduleLinker::getId)
+                .containsExactly(
+                        linker2.getId(),
+                        linker1.getId());
+    }
+
+
+
+    private void persist(Object ... objects) {
+        for (Object object : objects) {
+            em.persist(object);
+        }
+        em.flush();
+        em.clear();
+    }
+}

--- a/src/test/java/com/peoplein/moiming/repository/jpa/MoimPostJpaRepositoryTest.java
+++ b/src/test/java/com/peoplein/moiming/repository/jpa/MoimPostJpaRepositoryTest.java
@@ -5,10 +5,10 @@ import com.peoplein.moiming.TestUtils;
 import com.peoplein.moiming.domain.*;
 import com.peoplein.moiming.repository.*;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -158,5 +158,150 @@ public class MoimPostJpaRepositoryTest extends BaseTest {
 
         MoimPost removedMoim = moimPostRepository.findById(moimPost.getId());
         assertThat(removedMoim).isNull();
+    }
+
+    @Test
+    void findNoticesLatest3ByMoimIdSuccess1Test() {
+        // Given :
+        Moim moim1 = TestUtils.createMoimOnly("other1");
+        Moim moim2 = TestUtils.createMoimOnly("other2");
+        Moim moim3 = TestUtils.createMoimOnly("other3");
+
+        MemberMoimLinker linker1 = TestUtils.createLeaderMemberMoimLinker(member, moim1);
+        MemberMoimLinker linker2 = TestUtils.createLeaderMemberMoimLinker(member, moim2);
+        MemberMoimLinker linker3 = TestUtils.createLeaderMemberMoimLinker(member, moim2);
+
+        saveEntities(member, moim1, moim2, moim3, linker1, linker2, linker3);
+
+        MoimPost moimPost1 = TestUtils.initNoticeMoimPost(moim1, member);
+        MoimPost moimPost2 = TestUtils.initNoticeMoimPost(moim1, member);
+        MoimPost moimPost3 = TestUtils.initNoticeMoimPost(moim1, member);
+
+        saveEntities(moimPost1, moimPost2, moimPost3);
+
+        MoimPost moimPost4 = TestUtils.initNoticeMoimPost(moim2, member);
+
+        saveEntities(moimPost4);
+
+        MoimPost moimPost7 = TestUtils.initNoticeMoimPost(moim3, member);
+        MoimPost moimPost8 = TestUtils.initNoticeMoimPost(moim3, member);
+        MoimPost moimPost9 = TestUtils.initNoticeMoimPost(moim3, member);
+
+        saveEntities(moimPost7, moimPost8, moimPost9);
+
+
+        List<Long> moimIds = List.of(moim1.getId(), moim2.getId(), moim3.getId());
+
+        // When :
+        List<MoimPost> result = moimPostRepository.findNoticesLatest3ByMoimIds(moimIds);
+
+        // Then :
+        assertThat(result.size()).isEqualTo(3);
+        assertThat(result)
+                .extracting(MoimPost::getId)
+                .contains(moimPost7.getId(), moimPost8.getId(), moimPost9.getId());
+    }
+
+
+    @DisplayName("findNoticesLatest3ByMoimId : moimIds에 포함되지 않은 값이 나오지는 않는지 확인")
+    @Test
+    void findNoticesLatest3ByMoimIdSuccess2Test() {
+        // Given :
+        TestUtils.initMemberAndMemberInfo("other-member", "other-member@moimimgn.net");
+
+        Moim moim1 = TestUtils.createMoimOnly("other1");
+        Moim moim2 = TestUtils.createMoimOnly("other2");
+        Moim moim3 = TestUtils.createMoimOnly("other3");
+
+        MemberMoimLinker linker1 = TestUtils.createLeaderMemberMoimLinker(member, moim1);
+        MemberMoimLinker linker2 = TestUtils.createLeaderMemberMoimLinker(member, moim2);
+        MemberMoimLinker linker3 = TestUtils.createLeaderMemberMoimLinker(member, moim2);
+
+        saveEntities(member, moim1, moim2, moim3, linker1, linker2, linker3);
+
+        MoimPost moimPost1 = TestUtils.initNoticeMoimPost(moim1, member);
+        MoimPost moimPost2 = TestUtils.initNoticeMoimPost(moim1, member);
+        MoimPost moimPost3 = TestUtils.initNoticeMoimPost(moim1, member);
+
+        saveEntities(moimPost1, moimPost2, moimPost3);
+
+        MoimPost moimPost4 = TestUtils.initNoticeMoimPost(moim2, member);
+
+        saveEntities(moimPost4);
+
+        MoimPost moimPost7 = TestUtils.initNoticeMoimPost(moim3, member);
+        MoimPost moimPost8 = TestUtils.initNoticeMoimPost(moim3, member);
+        MoimPost moimPost9 = TestUtils.initNoticeMoimPost(moim3, member);
+
+        saveEntities(moimPost7, moimPost8, moimPost9);
+
+
+        List<Long> moimIds = List.of(moim1.getId());
+
+        // When :
+        List<MoimPost> result = moimPostRepository.findNoticesLatest3ByMoimIds(moimIds);
+
+        // Then :
+        assertThat(result.size()).isEqualTo(3);
+        assertThat(result)
+                .extracting(MoimPost::getId)
+                .contains(moimPost1.getId(), moimPost2.getId(), moimPost3.getId());
+    }
+
+    @DisplayName("findNoticesLatest3ByMoimId : 순서대로 나오는지 확인")
+    @Test
+    void findNoticesLatest3ByMoimIdSuccess3Test() {
+        // Given :
+        TestUtils.initMemberAndMemberInfo("other-member", "other-member@moimimgn.net");
+
+        Moim moim1 = TestUtils.createMoimOnly("other1");
+        Moim moim2 = TestUtils.createMoimOnly("other2");
+        Moim moim3 = TestUtils.createMoimOnly("other3");
+
+        MemberMoimLinker linker1 = TestUtils.createLeaderMemberMoimLinker(member, moim1);
+        MemberMoimLinker linker2 = TestUtils.createLeaderMemberMoimLinker(member, moim2);
+        MemberMoimLinker linker3 = TestUtils.createLeaderMemberMoimLinker(member, moim2);
+
+        saveEntities(member, moim1, moim2, moim3, linker1, linker2, linker3);
+
+        MoimPost moimPost1 = TestUtils.initNoticeMoimPost(moim1, member);
+        MoimPost moimPost2 = TestUtils.initNoticeMoimPost(moim1, member);
+        MoimPost moimPost3 = TestUtils.initNoticeMoimPost(moim1, member);
+
+        saveEntities(moimPost1, moimPost2, moimPost3);
+
+        MoimPost moimPost4 = TestUtils.initNoticeMoimPost(moim2, member);
+
+        saveEntities(moimPost4);
+
+        MoimPost moimPost7 = TestUtils.initNoticeMoimPost(moim3, member);
+        MoimPost moimPost8 = TestUtils.initNoticeMoimPost(moim3, member);
+        MoimPost moimPost9 = TestUtils.initNoticeMoimPost(moim3, member);
+
+        saveEntities(moimPost7, moimPost8, moimPost9);
+
+
+        List<Long> moimIds = List.of(moim1.getId(), moim2.getId());
+
+        // When :
+        List<MoimPost> result = moimPostRepository.findNoticesLatest3ByMoimIds(moimIds);
+
+        // Then :
+        assertThat(result.size()).isEqualTo(3);
+        assertThat(result)
+                .extracting(MoimPost::getId)
+                .contains(moimPost4.getId(), moimPost3.getId(), moimPost2.getId());
+        assertThat(result)
+                .extracting(MoimPost::getId)
+                .doesNotContain(moimPost1.getId());
+    }
+
+    private void saveEntities(Object... objects) {
+        for (Object object : objects) {
+            System.out.println(object.toString());
+            em.persist(object);
+        }
+        em.flush();
+        em.clear();
     }
 }

--- a/src/test/java/com/peoplein/moiming/repository/jpa/MoimPostJpaRepositoryTest.java
+++ b/src/test/java/com/peoplein/moiming/repository/jpa/MoimPostJpaRepositoryTest.java
@@ -192,6 +192,7 @@ public class MoimPostJpaRepositoryTest extends BaseTest {
 
         List<Long> moimIds = List.of(moim1.getId(), moim2.getId(), moim3.getId());
 
+        System.out.println("HERE======================================");
         // When :
         List<MoimPost> result = moimPostRepository.findNoticesLatest3ByMoimIds(moimIds);
 
@@ -298,7 +299,6 @@ public class MoimPostJpaRepositoryTest extends BaseTest {
 
     private void saveEntities(Object... objects) {
         for (Object object : objects) {
-            System.out.println(object.toString());
             em.persist(object);
         }
         em.flush();

--- a/src/test/java/com/peoplein/moiming/repository/jpa/ScheduleJpaRepositoryTest.java
+++ b/src/test/java/com/peoplein/moiming/repository/jpa/ScheduleJpaRepositoryTest.java
@@ -1,0 +1,71 @@
+package com.peoplein.moiming.repository.jpa;
+
+import com.peoplein.moiming.BaseTest;
+import com.peoplein.moiming.TestUtils;
+import com.peoplein.moiming.domain.Member;
+import com.peoplein.moiming.domain.Moim;
+import com.peoplein.moiming.domain.Schedule;
+import com.peoplein.moiming.repository.ScheduleRepository;
+import com.querydsl.core.Tuple;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+@Rollback(value = false)
+public class ScheduleJpaRepositoryTest extends BaseTest {
+
+
+    @Autowired
+    EntityManager em;
+
+    @Autowired
+    ScheduleRepository scheduleRepository;
+
+
+
+    @Test
+    void test1() {
+
+//        Moim moim = TestUtils.createMoimOnly();
+//        Member member = TestUtils.initMemberAndMemberInfo();
+//
+//        em.persist(member.getRoles().get(0).getRole());
+//        em.persist(member);
+//        em.persist(moim);
+//
+//        Schedule schedule1 = Schedule.createSchedule("a", "a", LocalDateTime.of(2023, 1, 10, 6, 30), 10, moim, member);
+//        Schedule schedule2 = Schedule.createSchedule("a", "a", LocalDateTime.of(2022, 1, 10, 6, 30), 10, moim, member);
+//        Schedule schedule3 = Schedule.createSchedule("a", "a", LocalDateTime.of(2021, 1, 10, 6, 30), 10, moim, member);
+//        Schedule schedule4 = Schedule.createSchedule("a", "a", LocalDateTime.of(2020, 1, 10, 6, 30), 10, moim, member);
+//
+//        em.persist(schedule1);
+//        em.persist(schedule2);
+//        em.persist(schedule3);
+//        em.persist(schedule4);
+//
+//        em.flush();
+//        em.clear();
+//
+//
+//        List<Tuple> latestScheduleEachMoim = scheduleRepository.findLatestScheduleEachMoim();
+//        for (Tuple tuple : latestScheduleEachMoim) {
+//            System.out.println(tuple);
+//        }
+
+
+    }
+
+
+
+}

--- a/src/test/java/com/peoplein/moiming/service/MemberServiceIntegrationTest.java
+++ b/src/test/java/com/peoplein/moiming/service/MemberServiceIntegrationTest.java
@@ -1,0 +1,76 @@
+package com.peoplein.moiming.service;
+
+import com.peoplein.moiming.BaseTest;
+import com.peoplein.moiming.TestUtils;
+import com.peoplein.moiming.domain.Member;
+import com.peoplein.moiming.domain.Moim;
+import com.peoplein.moiming.domain.Schedule;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+@Rollback(value = false)
+class MemberServiceIntegrationTest extends BaseTest {
+
+    @Autowired
+    EntityManager em;
+
+    @Autowired
+    MemberService service;
+
+
+
+    @Test
+    void test1() {
+
+        // Given:
+        Member member = TestUtils.initMemberAndMemberInfo();
+        Moim moim1 = TestUtils.createMoimOnly();
+        Moim moim2 = TestUtils.createMoimOnly();
+
+        Schedule schedule1 = Schedule.createSchedule("a", "a", LocalDateTime.of(2023, 1, 1, 6, 30), 10, moim1, member);
+        Schedule schedule2 = Schedule.createSchedule("b", "b", LocalDateTime.of(2022, 1, 1, 6, 30), 10, moim1, member);
+        Schedule schedule3 = Schedule.createSchedule("c", "c", LocalDateTime.of(2027, 1, 1, 6, 30), 10, moim1, member);
+        Schedule schedule4 = Schedule.createSchedule("d", "d", LocalDateTime.of(2024, 1, 1, 6, 30), 10, moim1, member);
+
+        Schedule schedule5 = Schedule.createSchedule("A", "A", LocalDateTime.of(2023, 1, 1, 6, 30), 10, moim2, member);
+        Schedule schedule6 = Schedule.createSchedule("B", "B", LocalDateTime.of(2022, 1, 1, 6, 30), 10, moim2, member);
+        Schedule schedule7 = Schedule.createSchedule("C", "C", LocalDateTime.of(2027, 1, 1, 6, 30), 10, moim2, member);
+        Schedule schedule8 = Schedule.createSchedule("D", "D", LocalDateTime.of(2024, 1, 1, 6, 30), 10, moim2, member);
+
+        persist(member.getRoles().get(0).getRole(),
+                member, moim1, moim2,
+                schedule1,schedule2,schedule3,schedule4,schedule5,schedule6,schedule7,schedule8);
+
+
+
+        // When:
+        MemberService.MemberHomeDto memberHomeDto = service.serviceHome(member);
+
+        // Then:
+        assertThat(memberHomeDto.getMoimScheduleDto().getMoimScheduleMap().size()).isEqualTo(2);
+        assertThat(memberHomeDto.getMoimScheduleDto().getMoimScheduleMap().get(moim1)).isEqualTo(schedule3);
+        assertThat(memberHomeDto.getMoimScheduleDto().getMoimScheduleMap().get(moim2)).isEqualTo(schedule7);
+        assertThat(memberHomeDto.getMoimNotices().size()).isEqualTo(0);
+        assertThat(memberHomeDto.getMemberSchedule().size()).isEqualTo(5);
+    }
+
+    private void persist(Object ... objects) {
+        Arrays.stream(objects).forEach(o -> em.persist(o));
+    }
+
+
+}

--- a/src/test/java/com/peoplein/moiming/service/MoimPostServiceTest.java
+++ b/src/test/java/com/peoplein/moiming/service/MoimPostServiceTest.java
@@ -143,6 +143,9 @@ public class MoimPostServiceTest extends BaseTest {
     }
 
     void persist(Object ... objects) {
+        for (Object object : objects) {
+
+        }
         Arrays.stream(objects).forEach(o -> em.persist(o));
     }
 }


### PR DESCRIPTION
### update_At null인 경우를 발견하고 수정
- 이 커밋은 BaseEntity를 사용하는 녀석이 처음 em.persist()를 했을 때, update_at 필드값이 항상 null인 것을 확인하고 해결한 커밋입니다. 


### 모임들에서 최근 3개 공지 가져오기 쿼리 개발 ~ 코드 다이어트 && Lombok 일부 제거
- 이 커밋들은 아래 화면을 위한 데이터 서빙을 개발했습니다. 
- Moim별 최근 모임을 보여주는 기능은 JPA만으로는 서브 쿼리(?)를 이용해서 적절한 데이터를 가져오는게 되지 않아서, 우선은 모든 모임 / 스케쥴을 찾아서 어플리케이션 단에서 처리해주는 형식입니다.
- 회비 납부 일정 기능은 구현되지 않아서 일단은 스킵하고 구현했습니다.
- 어떤 데이터를 프론트에 넘겨줘야하는지 정의되지 않아서, Service 단에서는 Entity를 반환하도록 수정했습니다. 데이터가 결정되면 Controller 단에서 한번 변환해서 프론트로 전달해주는 방식이 되면 좋을 것 같습니다.

![image](https://user-images.githubusercontent.com/126734704/236627125-0edf8db1-a99a-43ba-983b-35769f3036cf.png)
