### PR TITLE
ScheduleService Refactoring

### DIFF
--- a/src/main/java/com/peoplein/moiming/MoimingApplication.java
+++ b/src/main/java/com/peoplein/moiming/MoimingApplication.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
 
 import java.io.FileInputStream;
@@ -16,28 +17,8 @@ import java.io.IOException;
 
 @SpringBootApplication
 public class MoimingApplication {
-    @Value("${app_files.fcm_path}")
-    private String fcmFilePath;
 
     public static void main(String[] args) {
         SpringApplication.run(MoimingApplication.class, args);
     }
-
-    /*
-     앱 시작시 Firebase 연동 (수명주기중 한 번 수행)
-     */
-    @EventListener(ApplicationReadyEvent.class)
-    public void initFirebaseApp() throws IOException {
-
-        FileInputStream serviceAccount =
-                new FileInputStream(fcmFilePath);
-
-        FirebaseOptions options = new FirebaseOptions.Builder()
-                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
-                .build();
-
-        FirebaseApp.initializeApp(options);
-        System.out.println("FIREBASE INITIALIZE COMPLETE");
-    }
-
 }

--- a/src/main/java/com/peoplein/moiming/controller/ScheduleController.java
+++ b/src/main/java/com/peoplein/moiming/controller/ScheduleController.java
@@ -78,7 +78,10 @@ public class ScheduleController {
     @PatchMapping("/state/{scheduleId}")
     public ResponseModel<ScheduleMemberDto> changeMemberState(@PathVariable(name = "scheduleId") Long scheduleId, @RequestParam(name = "join") boolean isJoin) {
         Member curMember = (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        ScheduleMemberDto scheduleMemberDto = scheduleService.changeMemberState(scheduleId, isJoin, curMember);
+
+        ScheduleService.ChangeMemberTuple tuple = scheduleService.changeMemberState(scheduleId, isJoin, curMember);
+        ScheduleMemberDto scheduleMemberDto = ScheduleMemberDto.create(tuple);
+
         return ResponseModel.createResponse(scheduleMemberDto);
     }
 

--- a/src/main/java/com/peoplein/moiming/domain/Member.java
+++ b/src/main/java/com/peoplein/moiming/domain/Member.java
@@ -129,4 +129,8 @@ public class Member extends BaseEntity {
     public void setFcmToken(String fcmToken) {
         this.fcmToken = fcmToken;
     }
+
+    public boolean isSameUid(String uid) {
+        return this.uid.equals(uid);
+    }
 }

--- a/src/main/java/com/peoplein/moiming/domain/MemberMoimLinker.java
+++ b/src/main/java/com/peoplein/moiming/domain/MemberMoimLinker.java
@@ -144,4 +144,10 @@ public class MemberMoimLinker extends BaseEntity {
         this.moim.minusCurMemberCount();
         this.memberState = moimMemberState;
     }
+
+    // 스케쥴 변경 권한은 LEADER / MANAGER만 있음.
+    public boolean hasPermissionForUpdate() {
+        return this.moimRoleType.equals(MoimRoleType.LEADER) ||
+                this.moimRoleType.equals(MoimRoleType.MANAGER);
+    }
 }

--- a/src/main/java/com/peoplein/moiming/domain/MemberScheduleLinker.java
+++ b/src/main/java/com/peoplein/moiming/domain/MemberScheduleLinker.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MemberScheduleLinker {
+public class MemberScheduleLinker extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE)
@@ -20,8 +20,6 @@ public class MemberScheduleLinker {
 
     @Enumerated(value = EnumType.STRING)
     private ScheduleMemberState memberState;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "schedule_id")
@@ -46,7 +44,6 @@ public class MemberScheduleLinker {
         /*
          초기화
          */
-        this.createdAt = LocalDateTime.now();
 
         /*
          연관관계 및 편의 메소드
@@ -62,7 +59,4 @@ public class MemberScheduleLinker {
     }
 
 
-    public void setUpdatedAt(LocalDateTime updatedAt) {
-        this.updatedAt = updatedAt;
-    }
 }

--- a/src/main/java/com/peoplein/moiming/domain/MemberScheduleLinker.java
+++ b/src/main/java/com/peoplein/moiming/domain/MemberScheduleLinker.java
@@ -53,5 +53,14 @@ public class MemberScheduleLinker extends BaseEntity{
         this.memberState = memberState;
     }
 
+    public void changeMemberStateWithJoin(boolean isJoin) {
+        if (isJoin)
+            this.memberState = ScheduleMemberState.ATTEND;
+        else
+            this.memberState = ScheduleMemberState.NONATTEND;
+
+    }
+
+
 
 }

--- a/src/main/java/com/peoplein/moiming/domain/MemberScheduleLinker.java
+++ b/src/main/java/com/peoplein/moiming/domain/MemberScheduleLinker.java
@@ -42,15 +42,10 @@ public class MemberScheduleLinker extends BaseEntity{
         this.memberState = memberState;
 
         /*
-         초기화
-         */
-
-        /*
          연관관계 및 편의 메소드
          */
         this.schedule = schedule;
-        this.schedule.getMemberScheduleLinkers().add(this);
-
+        this.schedule.addScheduleLinker(this);
     }
 
     public void changeMemberState(ScheduleMemberState memberState) {

--- a/src/main/java/com/peoplein/moiming/domain/MemberScheduleLinker.java
+++ b/src/main/java/com/peoplein/moiming/domain/MemberScheduleLinker.java
@@ -53,14 +53,4 @@ public class MemberScheduleLinker extends BaseEntity{
         this.memberState = memberState;
     }
 
-    public void changeMemberStateWithJoin(boolean isJoin) {
-        if (isJoin)
-            this.memberState = ScheduleMemberState.ATTEND;
-        else
-            this.memberState = ScheduleMemberState.NONATTEND;
-
-    }
-
-
-
 }

--- a/src/main/java/com/peoplein/moiming/domain/Schedule.java
+++ b/src/main/java/com/peoplein/moiming/domain/Schedule.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Schedule {
+public class Schedule extends BaseEntity{
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE)
@@ -24,9 +24,7 @@ public class Schedule {
     private LocalDateTime scheduleDate;
     private int maxCount;
     private boolean isClosed;
-    private LocalDateTime createdAt;
     private String createdUid;
-    private LocalDateTime updatedAt;
     private String updatedUid;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -56,7 +54,6 @@ public class Schedule {
          초기화
          */
         this.isClosed = false;
-        this.createdAt = LocalDateTime.now();
 
         /*
          연관관계 및 편의 메소드
@@ -88,7 +85,4 @@ public class Schedule {
         this.updatedUid = updatedUid;
     }
 
-    public void setUpdatedAt(LocalDateTime updatedAt) {
-        this.updatedAt = updatedAt;
-    }
 }

--- a/src/main/java/com/peoplein/moiming/domain/Schedule.java
+++ b/src/main/java/com/peoplein/moiming/domain/Schedule.java
@@ -85,4 +85,11 @@ public class Schedule extends BaseEntity{
         this.updatedUid = updatedUid;
     }
 
+    public void addScheduleLinker(MemberScheduleLinker memberScheduleLinker) {
+        if (this.maxCount < this.memberScheduleLinkers.size() + 1) {
+            throw new RuntimeException("모임 스케쥴의 최대값을 넘는 값입니다.");
+        }
+        memberScheduleLinkers.add(memberScheduleLinker);
+    }
+
 }

--- a/src/main/java/com/peoplein/moiming/domain/Schedule.java
+++ b/src/main/java/com/peoplein/moiming/domain/Schedule.java
@@ -58,7 +58,8 @@ public class Schedule extends BaseEntity{
         /*
          연관관계 및 편의 메소드
          */
-        this.memberScheduleLinkers.add(MemberScheduleLinker.memberJoinSchedule(creator, this, ScheduleMemberState.CREATOR));
+        MemberScheduleLinker.memberJoinSchedule(creator, this, ScheduleMemberState.CREATOR);
+        // this.memberScheduleLinkers.add(MemberScheduleLinker.memberJoinSchedule(creator, this, ScheduleMemberState.CREATOR));
         this.moim = moim;
     }
 
@@ -91,5 +92,17 @@ public class Schedule extends BaseEntity{
         }
         memberScheduleLinkers.add(memberScheduleLinker);
     }
+
+    public boolean hasAnyUpdate(String changedTitle,
+                                String changedLocation,
+                                LocalDateTime changedTime,
+                                int changedMaxCount) {
+
+        return !this.scheduleTitle.equals(changedTitle) ||
+                !this.scheduleLocation.equals(changedLocation) ||
+                !this.scheduleDate.equals(changedTime) ||
+                this.maxCount != changedMaxCount;
+    }
+
 
 }

--- a/src/main/java/com/peoplein/moiming/external/FirebaseService.java
+++ b/src/main/java/com/peoplein/moiming/external/FirebaseService.java
@@ -1,0 +1,56 @@
+package com.peoplein.moiming.external;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.event.EventListener;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+@Slf4j
+@Profile(value = "production")
+public class FirebaseService {
+
+    @Value("${app_files.fcm_path}")
+    private String fcmFilePath;
+
+    /*
+     앱 시작시 Firebase 연동 (수명주기중 한 번 수행)
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    public void initFirebaseApp() throws IOException {
+
+        FileInputStream serviceAccount =
+                new FileInputStream(fcmFilePath);
+
+        FirebaseOptions options = new FirebaseOptions.Builder()
+                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .build();
+
+        FirebaseApp firebaseApp = FirebaseApp.initializeApp(options);
+
+        // For Shutdown Hook.
+        Runtime.getRuntime().addShutdownHook(new Thread(new FirebaseShutDownRunnable(firebaseApp)));
+        log.info("FIREBASE INITIALIZE COMPLETE");
+    }
+
+    private static class FirebaseShutDownRunnable implements Runnable {
+
+        private final FirebaseApp firebaseApp;
+
+        public FirebaseShutDownRunnable(FirebaseApp firebaseApp) {
+            this.firebaseApp = firebaseApp;
+        }
+
+        @Override
+        public void run() {
+            firebaseApp.delete();
+        }
+    }
+
+}

--- a/src/main/java/com/peoplein/moiming/model/dto/domain/MoimMemberInfoDto.java
+++ b/src/main/java/com/peoplein/moiming/model/dto/domain/MoimMemberInfoDto.java
@@ -64,9 +64,19 @@ public class MoimMemberInfoDto {
         } else {
             this.updatedAt = memberMoimLinker.getUpdatedAt();
         }
-
     }
 
+    public static MoimMemberInfoDto createWithMemberMoimLinker(MemberMoimLinker memberMoimLinker) {
+        return new MoimMemberInfoDto(
+                memberMoimLinker.getMember().getId(),
+                memberMoimLinker.getMember().getUid(),
+                memberMoimLinker.getMember().getMemberInfo().getMemberName(),
+                memberMoimLinker.getMember().getMemberInfo().getMemberEmail(),
+                memberMoimLinker.getMember().getMemberInfo().getMemberGender(),
+                memberMoimLinker.getMember().getMemberInfo().getMemberPfImg(),
+                memberMoimLinker.getMoimRoleType(), memberMoimLinker.getMemberState(),
+                memberMoimLinker.getCreatedAt(), memberMoimLinker.getUpdatedAt());
+    }
 
     /*
      MemberMoimLinker 정보 세팅을 위한 setter open

--- a/src/main/java/com/peoplein/moiming/model/dto/domain/ScheduleDto.java
+++ b/src/main/java/com/peoplein/moiming/model/dto/domain/ScheduleDto.java
@@ -39,4 +39,19 @@ public class ScheduleDto {
         this.updatedAt = schedule.getUpdatedAt();
         this.updatedUid = schedule.getUpdatedUid();
     }
+
+    public static ScheduleDto createScheduleDto(Schedule schedule) {
+        return new ScheduleDto(
+                schedule.getId(),
+                schedule.getScheduleTitle(),
+                schedule.getScheduleLocation(),
+                schedule.getScheduleDate(),
+                schedule.getMaxCount(),
+                schedule.isClosed(),
+                schedule.getCreatedAt(),
+                schedule.getCreatedUid(),
+                schedule.getUpdatedAt(),
+                schedule.getUpdatedUid()
+        );
+    }
 }

--- a/src/main/java/com/peoplein/moiming/model/dto/domain/ScheduleMemberDto.java
+++ b/src/main/java/com/peoplein/moiming/model/dto/domain/ScheduleMemberDto.java
@@ -2,6 +2,7 @@ package com.peoplein.moiming.model.dto.domain;
 
 import com.peoplein.moiming.domain.MemberScheduleLinker;
 import com.peoplein.moiming.domain.enums.ScheduleMemberState;
+import com.peoplein.moiming.service.ScheduleService;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -38,4 +39,14 @@ public class ScheduleMemberDto {
     public void setMoimMemberInfoDto(MoimMemberInfoDto moimMemberInfoDto) {
         this.moimMemberInfoDto = moimMemberInfoDto;
     }
+
+    public static ScheduleMemberDto create(ScheduleService.ChangeMemberTuple tuple) {
+        ScheduleMemberDto scheduleMemberDto = new ScheduleMemberDto(tuple.getMemberScheduleLinker().getMemberState(),
+                tuple.getMemberScheduleLinker().getCreatedAt(),
+                tuple.getMemberScheduleLinker().getUpdatedAt());
+        scheduleMemberDto.setMoimMemberInfoDto(tuple.getMoimMemberInfoDto());
+        return scheduleMemberDto;
+    }
+
+
 }

--- a/src/main/java/com/peoplein/moiming/model/dto/domain/ScheduleMemberDto.java
+++ b/src/main/java/com/peoplein/moiming/model/dto/domain/ScheduleMemberDto.java
@@ -1,5 +1,6 @@
 package com.peoplein.moiming.model.dto.domain;
 
+import com.peoplein.moiming.domain.MemberScheduleLinker;
 import com.peoplein.moiming.domain.enums.ScheduleMemberState;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -22,6 +23,17 @@ public class ScheduleMemberDto {
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
+
+    public static ScheduleMemberDto create(MemberScheduleLinker memberScheduleLinker,
+                                           MoimMemberInfoDto moimMemberInfoDto) {
+        ScheduleMemberDto scheduleMemberDto = new ScheduleMemberDto(
+                memberScheduleLinker.getMemberState(),
+                memberScheduleLinker.getCreatedAt(),
+                memberScheduleLinker.getUpdatedAt());
+        scheduleMemberDto.setMoimMemberInfoDto(moimMemberInfoDto);
+        return scheduleMemberDto;
+    }
+
 
     public void setMoimMemberInfoDto(MoimMemberInfoDto moimMemberInfoDto) {
         this.moimMemberInfoDto = moimMemberInfoDto;

--- a/src/main/java/com/peoplein/moiming/model/dto/response/ScheduleResponseDto.java
+++ b/src/main/java/com/peoplein/moiming/model/dto/response/ScheduleResponseDto.java
@@ -23,4 +23,11 @@ public class ScheduleResponseDto {
     public void setScheduleMemberDto(List<ScheduleMemberDto> scheduleMemberDto) {
         this.scheduleMemberDto = scheduleMemberDto;
     }
+
+    public static ScheduleResponseDto create(ScheduleDto scheduleDto, List<ScheduleMemberDto> scheduleMemberDto) {
+        ScheduleResponseDto scheduleResponseDto = new ScheduleResponseDto(scheduleDto);
+        scheduleResponseDto.setScheduleMemberDto(scheduleMemberDto);
+        return scheduleResponseDto;
+    }
+
 }

--- a/src/main/java/com/peoplein/moiming/service/ScheduleService.java
+++ b/src/main/java/com/peoplein/moiming/service/ScheduleService.java
@@ -176,7 +176,6 @@ public class ScheduleService {
 
         if (isAnyUpdate) {
 
-            schedule.setUpdatedAt(LocalDateTime.now());
             schedule.setUpdatedUid(curMember.getUid());
 
             return buildScheduleResponseDto(schedule);
@@ -326,12 +325,12 @@ public class ScheduleService {
             if (isJoin) {
                 if (memberScheduleLinker.getMemberState() != ScheduleMemberState.ATTEND) {
                     memberScheduleLinker.changeMemberState(ScheduleMemberState.ATTEND);
-                    memberScheduleLinker.setUpdatedAt(LocalDateTime.now());
+                    // memberScheduleLinker.setUpdatedAt(LocalDateTime.now());
                 }
             } else {
                 if (memberScheduleLinker.getMemberState() != ScheduleMemberState.NONATTEND) {
                     memberScheduleLinker.changeMemberState(ScheduleMemberState.NONATTEND);
-                    memberScheduleLinker.setUpdatedAt(LocalDateTime.now());
+                    // memberScheduleLinker.setUpdatedAt(LocalDateTime.now());
                 }
             }
 

--- a/src/main/java/com/peoplein/moiming/service/ScheduleService.java
+++ b/src/main/java/com/peoplein/moiming/service/ScheduleService.java
@@ -123,7 +123,9 @@ public class ScheduleService {
         // When repository does not have such schedule in DB.
         String errorMessage = "요청한 일정을 찾을 수 없는 경우";
         throwIfObjectIsNull(schedule, errorMessage);
-        checkAuthorityForUpdate(curMember, schedule);
+
+        String authorityFailMessage = "일정을 수정할 권한이 없는 경우 :: 일정 생성자, 모임장, 운영진이 아님";
+        checkAuthority(curMember, schedule, authorityFailMessage);
 
         boolean isAnyUpdated = updateSchedule(scheduleRequestDto, schedule, curMember.getUid());
 
@@ -306,16 +308,6 @@ public class ScheduleService {
                 requestDto.getMaxCount(),
                 moim,
                 curMember);
-    }
-
-    // 변경할 권한 유저 체킹 - 생성자, 리더, 운영진 가능
-    // 요청한 유저와 이 Schedule 의 Moim Id 확보 필요
-    private void checkAuthorityForUpdate(Member curMember, Schedule schedule) {
-        MemberMoimLinker memberMoimLinker = memberMoimLinkerRepository.findByMemberAndMoimId(curMember.getId(), schedule.getMoim().getId());
-        if (!hasPermissionForUpdateSchedule(curMember, schedule, memberMoimLinker)) { // 일정 생성자가 아니다
-            log.error("일정을 수정할 권한이 없는 경우 :: 일정 생성자, 모임장, 운영진이 아님");
-            throw new RuntimeException("일정을 수정할 권한이 없는 경우 :: 일정 생성자, 모임장, 운영진이 아님");
-        }
     }
 
     // 변경할 권한 유저 체킹 - 생성자, 리더, 운영진 가능

--- a/src/main/java/com/peoplein/moiming/service/ScheduleService.java
+++ b/src/main/java/com/peoplein/moiming/service/ScheduleService.java
@@ -122,7 +122,7 @@ public class ScheduleService {
 
         // When repository does not have such schedule in DB.
         String errorMessage = "요청한 일정을 찾을 수 없는 경우";
-        throwIfScheduleIsNull(schedule, errorMessage);
+        throwIfObjectIsNull(schedule, errorMessage);
         checkAuthorityForUpdate(curMember, schedule);
 
         boolean isAnyUpdated = updateSchedule(scheduleRequestDto, schedule, curMember.getUid());
@@ -160,7 +160,7 @@ public class ScheduleService {
         Schedule schedule = scheduleRepository.findById(scheduleId);
 
         String errorMessage = "요청한 일정을 찾을 수 없는 경우";
-        throwIfScheduleIsNull(schedule, errorMessage);
+        throwIfObjectIsNull(schedule, errorMessage);
 
         String failMessage = "일정을 삭제할 권한이 없는 경우 :: 일정 생성자, 모임장, 운영진이 아님";
         checkAuthority(curMember, schedule, failMessage);
@@ -174,18 +174,12 @@ public class ScheduleService {
     public ScheduleMemberDto changeMemberState(Long scheduleId, boolean isJoin, Member curMember) {
 
         Schedule schedule = scheduleRepository.findById(scheduleId);
-
-        if (Objects.isNull(schedule)) {
-            log.error("잘못된 요청 : 해당 PK의 일정이 존재하지 않습니다");
-            throw new RuntimeException("잘못된 요청 : 해당 PK의 일정이 존재하지 않습니다");
-        }
+        String errorMessageForSchedule = "잘못된 요청 : 해당 PK의 일정이 존재하지 않습니다";
+        throwIfObjectIsNull(schedule, errorMessageForSchedule);
 
         MemberMoimLinker curMemberMoimLinker = memberMoimLinkerRepository.findWithMemberInfoByMemberAndMoimId(curMember.getId(), schedule.getMoim().getId());
-
-        if (Objects.isNull(curMemberMoimLinker)) {
-            log.error("잘못된 요청 : 모임원이 아닙니다");
-            throw new RuntimeException("잘못된 요청 : 모임원이 아닙니다");
-        }
+        String errorMessageForLinker = "잘못된 요청 : 모임원이 아닙니다";
+        throwIfObjectIsNull(curMemberMoimLinker, errorMessageForLinker);
 
         MoimMemberInfoDto moimMemberInfoDto = new MoimMemberInfoDto(
                 curMemberMoimLinker.getMember().getId(), curMemberMoimLinker.getMember().getUid()
@@ -344,6 +338,12 @@ public class ScheduleService {
         }
     }
 
+    private void throwIfObjectIsNull(Object object, String message) {
+        if (Objects.isNull(object)) {
+            log.error(message);
+            throw new RuntimeException(message);
+        }
+    }
 
 
 }

--- a/src/main/java/com/peoplein/moiming/service/ScheduleService.java
+++ b/src/main/java/com/peoplein/moiming/service/ScheduleService.java
@@ -45,7 +45,6 @@ public class ScheduleService {
         // TODO :: 현재 모임원들에게 FCM Push 를 전송한다
         if (requestDto.isFullNotice()) {
         }
-
         Moim findMoim = moimRepository.findById(requestDto.getMoimId());
 
         Schedule newSchedule = createNewScheduleWithDto(requestDto, findMoim, curMember);
@@ -280,12 +279,6 @@ public class ScheduleService {
 
     private boolean hasPermissionForUpdateSchedule(Member curMember, Schedule schedule, MemberMoimLinker memberMoimLinker) {
         return curMember.isSameUid(schedule.getCreatedUid()) || memberMoimLinker.hasPermissionForUpdate();
-    }
-    private void throwIfScheduleIsNull(Schedule schedule, String message) {
-        if (Objects.isNull(schedule)) {
-            log.error(message);
-            throw new RuntimeException(message);
-        }
     }
 
     private void throwIfObjectIsNull(Object object, String message) {

--- a/src/main/java/com/peoplein/moiming/service/ScheduleService.java
+++ b/src/main/java/com/peoplein/moiming/service/ScheduleService.java
@@ -273,7 +273,7 @@ public class ScheduleService {
         MemberMoimLinker memberMoimLinker = memberMoimLinkerRepository.findByMemberAndMoimId(curMember.getId(), schedule.getMoim().getId());
         if (!hasPermissionForUpdateSchedule(curMember, schedule, memberMoimLinker)) { // 일정 생성자가 아니다
             log.error(failMessage);
-            throw new RuntimeException("일정을 수정할 권한이 없는 경우 :: 일정 생성자, 모임장, 운영진이 아님");
+            throw new RuntimeException(failMessage);
         }
     }
 

--- a/src/main/java/com/peoplein/moiming/service/ScheduleService.java
+++ b/src/main/java/com/peoplein/moiming/service/ScheduleService.java
@@ -184,14 +184,12 @@ public class ScheduleService {
 
         // 해당 멤버에 대한 ScheduleLinker 가 있는지 우선 조회
         MemberScheduleLinker memberScheduleLinker = memberScheduleLinkerRepository.findWithScheduleByMemberAndScheduleId(curMember.getId(), scheduleId);
+        ScheduleMemberState scheduleMemberState = isJoin ? ScheduleMemberState.ATTEND : ScheduleMemberState.NONATTEND;
 
         if (Objects.isNull(memberScheduleLinker)) {
-            memberScheduleLinker =
-                    isJoin ?
-                    MemberScheduleLinker.memberJoinSchedule(curMember, schedule, ScheduleMemberState.ATTEND) :
-                    MemberScheduleLinker.memberJoinSchedule(curMember, schedule, ScheduleMemberState.NONATTEND);
+            memberScheduleLinker = MemberScheduleLinker.memberJoinSchedule(curMember, schedule, scheduleMemberState);
         } else {
-            memberScheduleLinker.changeMemberStateWithJoin(isJoin);
+            memberScheduleLinker.changeMemberState(scheduleMemberState);
         }
 
         MoimMemberInfoDto moimMemberInfoDto = MoimMemberInfoDto.createWithMemberMoimLinker(curMemberMoimLinker);

--- a/src/main/java/com/peoplein/moiming/service/shell/MoimServiceShell.java
+++ b/src/main/java/com/peoplein/moiming/service/shell/MoimServiceShell.java
@@ -99,6 +99,7 @@ public class MoimServiceShell {
         // persist
         createMoimCategoryLinker.forEach(moimCategoryLinkerRepository::save);
         moimRepository.save(createdMoim);
+        memberMoimLinkerRepository.save(curMemberMoimLinker);
 
         // response
         MoimMembersDto moimMembersDto = new MoimMembersDto(

--- a/src/test/java/com/peoplein/moiming/TestUtils.java
+++ b/src/test/java/com/peoplein/moiming/TestUtils.java
@@ -144,7 +144,9 @@ public class TestUtils {
     }
 
     public static Moim createMoimOnly() {
-        return Moim.createMoim(moimName, moimInfo, moimPfImg, new Area(areaState, areaCity), createdUid);
+        Moim moim = Moim.createMoim(moimName, moimInfo, moimPfImg, new Area(areaState, areaCity), createdUid);
+        moim.setHasRuleJoin(false);
+        return moim;
     }
 
     public static Moim createMoimOnly(String moimName) {

--- a/src/test/java/com/peoplein/moiming/TestUtils.java
+++ b/src/test/java/com/peoplein/moiming/TestUtils.java
@@ -107,7 +107,7 @@ public class TestUtils {
     }
 
     public static Member initMemberAndMemberInfo() {
-        Member member = Member.createMember(uid, password, memberEmail, memberName, memberGender, role);
+        Member member = Member.createMember(uid, password, memberEmail, memberName, fcmToken, memberGender, role);
         member.getMemberInfo().setMemberBirth(memberBirth);
 
         return member;
@@ -121,7 +121,7 @@ public class TestUtils {
     }
 
     public static Member initMemberAndMemberInfo(String uid, String memberName, String memberEmail) {
-        Member member = Member.createMember(uid, password, memberEmail, memberName, memberGender, role);
+        Member member = Member.createMember(uid, password, memberEmail, memberName, fcmToken, memberGender, role);
         member.getMemberInfo().setMemberBirth(memberBirth);
 
         return member;

--- a/src/test/java/com/peoplein/moiming/domain/MemberScheduleLinkerTest.java
+++ b/src/test/java/com/peoplein/moiming/domain/MemberScheduleLinkerTest.java
@@ -1,0 +1,64 @@
+package com.peoplein.moiming.domain;
+
+import com.peoplein.moiming.TestUtils;
+import com.peoplein.moiming.domain.enums.ScheduleMemberState;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+class MemberScheduleLinkerTest {
+
+    Moim moim;
+    Member creator;
+    Member joiner;
+    Schedule schedule;
+
+    @BeforeEach
+    void setUp() {
+
+        moim = TestUtils.createMoimOnly();
+        creator = TestUtils.initMemberAndMemberInfo();
+        joiner = TestUtils.initMemberAndMemberInfo("other-name", "other-email@mail.net");
+        schedule = Schedule.createSchedule(
+                "title",
+                "location",
+                LocalDateTime.of(2022, 1, 2, 6, 30),
+                10,
+                moim,
+                creator);
+    }
+
+    @Test
+    void constructorSuccessCaseTest() {
+        // When :
+        MemberScheduleLinker result = MemberScheduleLinker.memberJoinSchedule(joiner, schedule, ScheduleMemberState.ATTEND);
+
+        // Then
+        assertThat(result.getMember()).isEqualTo(joiner);
+        assertThat(result.getSchedule()).isEqualTo(schedule);
+        assertThat(result.getMemberState()).isEqualTo(ScheduleMemberState.ATTEND);
+    }
+
+    // max Count Validation.
+    @Test
+    void constructorFailCaseTest() {
+        // Given
+        Schedule schedule = Schedule.createSchedule(
+                "title",
+                "location",
+                LocalDateTime.of(2022, 1, 2, 6, 30),
+                1,
+                moim,
+                creator);
+
+        // When + Then :
+        assertThatThrownBy(() -> MemberScheduleLinker.memberJoinSchedule(joiner, schedule, ScheduleMemberState.ATTEND))
+                .isInstanceOf(RuntimeException.class);
+    }
+}

--- a/src/test/java/com/peoplein/moiming/domain/ScheduleTest.java
+++ b/src/test/java/com/peoplein/moiming/domain/ScheduleTest.java
@@ -1,0 +1,56 @@
+package com.peoplein.moiming.domain;
+
+import com.peoplein.moiming.TestUtils;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ScheduleTest {
+
+    @Test
+    void hasAnyUpdateTest1() {
+        // Given
+        Moim moim = TestUtils.createMoimOnly();
+        Member member = TestUtils.initMemberAndMemberInfo();
+        Schedule schedule = Schedule.createSchedule("title", "location",
+                getLocalDateTime(),
+                10,
+                moim,
+                member);
+
+        // When
+        boolean result = schedule.hasAnyUpdate("change-title", "location", getLocalDateTime(), 10);
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void hasAnyUpdateTest2() {
+        // Given
+        Moim moim = TestUtils.createMoimOnly();
+        Member member = TestUtils.initMemberAndMemberInfo();
+        Schedule schedule = Schedule.createSchedule("title", "location",
+                getLocalDateTime(),
+                10,
+                moim,
+                member);
+
+        // When
+        boolean result = schedule.hasAnyUpdate("title", "location", getLocalDateTime(), 10);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+
+    LocalDateTime getLocalDateTime() {
+        return LocalDateTime.of(2023, 1, 1, 1, 30);
+    }
+
+
+}

--- a/src/test/java/com/peoplein/moiming/service/ScheduleServiceTest.java
+++ b/src/test/java/com/peoplein/moiming/service/ScheduleServiceTest.java
@@ -1,0 +1,243 @@
+package com.peoplein.moiming.service;
+
+import com.peoplein.moiming.BaseTest;
+import com.peoplein.moiming.TestUtils;
+import com.peoplein.moiming.domain.Member;
+import com.peoplein.moiming.domain.MemberScheduleLinker;
+import com.peoplein.moiming.domain.Moim;
+import com.peoplein.moiming.domain.Schedule;
+import com.peoplein.moiming.domain.enums.MoimMemberStateAction;
+import com.peoplein.moiming.domain.enums.MoimRoleType;
+import com.peoplein.moiming.domain.enums.ScheduleMemberState;
+import com.peoplein.moiming.model.dto.request.MoimJoinRequestDto;
+import com.peoplein.moiming.model.dto.request.MoimMemberActionRequestDto;
+import com.peoplein.moiming.model.dto.request.ScheduleRequestDto;
+import com.peoplein.moiming.model.dto.response.ScheduleResponseDto;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import javax.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+//@Rollback(value = false)
+class ScheduleServiceTest extends BaseTest {
+
+
+    @Autowired
+    EntityManager em;
+
+    @Autowired
+    ScheduleService scheduleService;
+
+    @Autowired
+    MoimMemberService moimMemberService;
+
+    @Autowired
+    MoimService moimService;
+
+    @Test
+    @DisplayName("updateSchedule : 성공하는 경우")
+    void updateScheduleSuccessTest() {
+
+        // Given :
+        String expectedTitle = "change-title";
+        String expectedLocation = "change-location";
+        String expectedDate = "202301010130";
+        int expectedMaxCount = 15;
+
+
+        Member creator = TestUtils.initMemberAndMemberInfo("creator-uid","creator", "creator@gmail.com");
+        Member joiner = TestUtils.initMemberAndMemberInfo("joiner-uid","joiner", "joiner@gmail.com");
+        Moim moim = TestUtils.createMoimOnly();
+
+        persist(creator.getRoles().get(0).getRole(),
+                creator,
+                joiner,
+                moim);
+
+        MoimJoinRequestDto moimJoinRequestDto = new MoimJoinRequestDto(moim.getId());
+        moimMemberService.requestJoin(moimJoinRequestDto, creator);
+        moimMemberService.requestJoin(moimJoinRequestDto, joiner);
+
+        Schedule schedule = createScheduleForUpdate(moim, creator);
+        MemberScheduleLinker linker = MemberScheduleLinker.memberJoinSchedule(joiner, schedule, ScheduleMemberState.ATTEND);
+        persist(schedule, linker);
+
+        ScheduleRequestDto scheduleRequestDto = new ScheduleRequestDto(
+                moim.getId(),
+                schedule.getId(),
+                expectedTitle,
+                expectedLocation,
+                expectedDate,
+                expectedMaxCount,
+                false);
+
+        // When :
+        ScheduleResponseDto result = scheduleService.updateSchedule(scheduleRequestDto, creator);
+
+        // Then :
+        result.getScheduleMemberDto().sort((o1, o2) -> o1.getMoimMemberInfoDto().getMemberId().compareTo(o2.getMoimMemberInfoDto().getMemberId()));
+
+        assertThat(result.getScheduleMemberDto().size()).isEqualTo(2);
+        assertThat(result.getScheduleDto().getScheduleTitle()).isEqualTo(expectedTitle);
+        assertThat(result.getScheduleDto().getScheduleLocation()).isEqualTo(expectedLocation);
+        assertThat(result.getScheduleDto().getMaxCount()).isEqualTo(expectedMaxCount);
+    }
+
+
+    @Test
+    @DisplayName("updateSchedule : 바뀐 게 없을 때")
+    void updateScheduleFail2Test() {
+
+        // Given :
+        Member creator = TestUtils.initMemberAndMemberInfo("creator-uid","creator", "creator@gmail.com");
+        Member joiner = TestUtils.initMemberAndMemberInfo("joiner-uid","joiner", "joiner@gmail.com");
+        Moim moim = TestUtils.createMoimOnly();
+
+        persist(creator.getRoles().get(0).getRole(),
+                creator,
+                joiner,
+                moim);
+
+        MoimJoinRequestDto moimJoinRequestDto = new MoimJoinRequestDto(moim.getId());
+        moimMemberService.requestJoin(moimJoinRequestDto, creator);
+        moimMemberService.requestJoin(moimJoinRequestDto, joiner);
+
+        Schedule schedule = createScheduleForUpdate(moim, creator);
+        MemberScheduleLinker linker = MemberScheduleLinker.memberJoinSchedule(joiner, schedule, ScheduleMemberState.ATTEND);
+        persist(schedule, linker);
+
+        ScheduleRequestDto scheduleRequestDto = new ScheduleRequestDto(
+                moim.getId(),
+                schedule.getId(),
+                schedule.getScheduleTitle(),
+                schedule.getScheduleLocation(),
+                "202301010130",
+                schedule.getMaxCount(),
+                false);
+
+
+        // When + Then:
+        assertThatThrownBy(() -> scheduleService.updateSchedule(scheduleRequestDto, joiner))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+
+    @Test
+    @DisplayName("updateSchedule : 권한 없어서 실패")
+    void updateScheduleFailTest() {
+
+        // Given :
+        String expectedTitle = "change-title";
+        String expectedLocation = "change-location";
+        String expectedDate = "202301010130";
+        int expectedMaxCount = 15;
+
+        Member creator = TestUtils.initMemberAndMemberInfo("creator-uid","creator", "creator@gmail.com");
+        Member joiner = TestUtils.initMemberAndMemberInfo("joiner-uid","joiner", "joiner@gmail.com");
+        Moim moim = TestUtils.createMoimOnly();
+
+        persist(creator.getRoles().get(0).getRole(),
+                creator,
+                joiner,
+                moim);
+
+        MoimJoinRequestDto moimJoinRequestDto = new MoimJoinRequestDto(moim.getId());
+        moimMemberService.requestJoin(moimJoinRequestDto, creator);
+        moimMemberService.requestJoin(moimJoinRequestDto, joiner);
+
+        Schedule schedule = createScheduleForUpdate(moim, creator);
+        MemberScheduleLinker linker = MemberScheduleLinker.memberJoinSchedule(joiner, schedule, ScheduleMemberState.ATTEND);
+        persist(schedule, linker);
+
+        ScheduleRequestDto scheduleRequestDto = new ScheduleRequestDto(
+                moim.getId(),
+                schedule.getId(),
+                expectedTitle,
+                expectedLocation,
+                expectedDate,
+                expectedMaxCount,
+                false);
+
+
+        // When + Then:
+        assertThatThrownBy(() -> scheduleService.updateSchedule(scheduleRequestDto, joiner))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    @DisplayName("updateSchedule : 모임에 속하지 않았을 때, 삭제 요청하면? 실패")
+    void updateScheduleFail3Test() {
+
+        // Given :
+        String expectedTitle = "change-title";
+        String expectedLocation = "change-location";
+        String expectedDate = "202301010130";
+        int expectedMaxCount = 15;
+
+        Member creator = TestUtils.initMemberAndMemberInfo("creator-uid","creator", "creator@gmail.com");
+        Member joiner = TestUtils.initMemberAndMemberInfo("joiner-uid","joiner", "joiner@gmail.com");
+        Moim moim = TestUtils.createMoimOnly();
+        Moim otherMoim = TestUtils.createMoimOnly("other-moim");
+
+        persist(creator.getRoles().get(0).getRole(),
+                creator,
+                joiner,
+                moim,
+                otherMoim);
+
+        MoimJoinRequestDto moimJoinRequestDto = new MoimJoinRequestDto(moim.getId());
+        moimMemberService.requestJoin(moimJoinRequestDto, creator);
+
+        MoimJoinRequestDto ohterMoimJoinRequestDto = new MoimJoinRequestDto(otherMoim.getId());
+        moimMemberService.requestJoin(ohterMoimJoinRequestDto, joiner);
+
+        Schedule schedule = createScheduleForUpdate(moim, creator);
+        MemberScheduleLinker linker = MemberScheduleLinker.memberJoinSchedule(joiner, schedule, ScheduleMemberState.ATTEND);
+        persist(schedule, linker);
+
+        ScheduleRequestDto scheduleRequestDto = new ScheduleRequestDto(
+                moim.getId(),
+                schedule.getId(),
+                expectedTitle,
+                expectedLocation,
+                expectedDate,
+                expectedMaxCount,
+                false);
+
+
+        // When + Then:
+        assertThatThrownBy(() -> scheduleService.updateSchedule(scheduleRequestDto, joiner))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+
+    private void persist(Object ... objects) {
+        Arrays.stream(objects).forEach(o -> em.persist(o));
+    }
+
+    private Schedule createScheduleForUpdate(Moim moim, Member creator) {
+        return Schedule.createSchedule("title", "location",
+                LocalDateTime.of(2023, 1, 1, 1, 30),
+                10,
+                moim,
+                creator);
+    }
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -14,7 +14,11 @@ spring:
     properties:
       hibernate:
         show_sql: true
-        format_sql: true
+#        format_sql: true
     defer-datasource-initialization: true
     generate-ddl: true
     open-in-view: false
+
+
+app_files:
+  fcm_path: src/main/resources/fcm/moiming-b2ae3-firebase-adminsdk-21zjr-11c77c69f7.json


### PR DESCRIPTION
### FirebaseService 클래스로 분리
- 기존 방식으로는 테스트 코드에서 FirebaseService 때문에 반복해서 테스트를 할 수 없었음.
- @Profile 이용해서 테스트 코드에서는 실행되지 않도록 변경함.
- ShutDown Hook을 추가해서 스프링 어플리케이션 종료 시, fireBaseApp도 같이 종료되도록 수정. 


### Conflict Resolve
- 이전 Commit Merge 시, 테스트 코드에서 Conflict 있었으나 제대로 수정되지 않아서 컴파일 에러 발생 중이었음. 


### FCM Setting을 테스트 코드에 추가
- FCM Setting이 테스트 코드에 추가되어 있지 않아서 스프링 컨테이너가 정상적으로 생성되지 않은 부분을 해결함. 


### Apply BaseEntity to MemberScheduleLinker, Schedule
- MemberScheduleLinker, Schedule에 BaseEntity 상속하도록 적용함. 


### `MemberScheduleLinker`의 버그 픽스 + 제약 조건
- 기존에는 Schedule의 `MaxCount` 상관없이 계속 `MemberScheduleLinker`가 추가될 수 있었음. 
- 해당 부분을 validation해서 처리하도록 적용


### Refactoring `updateSchedule()`
- NullCheck 하는 부분 메서드로 추출 → `throwIfScheduleIsNull()`
- 권한 체크 하는 부분 메서드로 추출 → `checkAuthorityForUpdate()`
- 업데이트 및 업데이트 있는지 확인하는 부분 메서드로 추출 → `updateSchedule()`
- `List<ScheduleMemberDto> scheduleMemberDtos`를 생성하는 부분을 추출 → `getDtosIfMoimHasScheduleAndMember()`
  - Stream으로 처리하기 위해서 데이터 전달 클래스가 필요해 `Tuple` 클래스 생성
- 테스트 코드 작성 


### deleteSchedule 테스트 코드 작성 + 리팩토링
- 권한 체크 + Null 체크를 새롭게 추출된 메서드를 재사용함. `checkAuthority()`, `throwIfScheduleIsNull()`
- 불필요한 catch 문 제거
  - Repository에서 발생한 에러는 트랜잭션이 flush() 되는 시점에 발생하기 때문에 try ~ catch 문에서는 SQL 구문 문제 말고는 발생하지 않음. 그러나 쿼리는 정상적으로 작성되어있기 때문에 해당 try ~ catch 문에서는 어떠한 에러도 catch 할 수 없음.
  - 가독성을 해치기 때문에 삭제함.

### changeMemberState() 테스트 코드 작성 + 리팩토링
- `BaseEntity`를 추가하면서, 서비스 계층에서 `createdAt`, `updatedAt`은 트랜잭션이 커밋되는 순간 사용할 수 있음. 따라서 Entity를 컨트롤러로 반환하고, 컨트롤러에서 응답을 생성하도록 변경함. 
- 필요한 테스트 코드 작성. 
