### PR TITLE
Swagger USE JWT Token for API Request

### DIFF
--- a/src/main/java/com/peoplein/moiming/config/SwaggerConfiguration.java
+++ b/src/main/java/com/peoplein/moiming/config/SwaggerConfiguration.java
@@ -1,8 +1,11 @@
 package com.peoplein.moiming.config;
 
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springdoc.core.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
@@ -16,18 +19,34 @@ import java.util.List;
 public class SwaggerConfiguration {
     @Bean
     public OpenAPI openAPI() {
+
+        Info info = new Info().title("Moiming Devs API 명세서")
+                .description("### 에러코드 문서\n\n" +
+                        "https://docs.google.com/spreadsheets/d/1vkgXTrdumMbzeeNeGzC8MvOdo3CQGqyr/edit?usp=share_link&ouid=115296106035275739943&rtpof=true&sd=true\n\n" +
+                        "### 하기 문서의 모든 응답 Example Value 는 {\"data\":[Example Value]} 값으로 묶여있는 JSON 값입니다\n\n" +
+                        "**`Error Response Model`**\n\n" +
+                        "- errorCode : 에러코드명, 에러코드 문서에 명시되어 있습니다\n" +
+                        "- errorType : 에러 현황을 간략하게 알 수 있는 타입 값이 전달됩니다. 에러코드 문서에 명시되어 있습니다\n" +
+                        "- errorDesc : 서버에서 발생한 error exception 의 메세지를 전달합니다.\n\n\n" +
+                        "**`Execute 실행 시, JWT 토큰을 Authorize에서 포함하세요`**\n" +
+                        "- curl -X POST -H \"Content-Type: application/json\" -d '{\"uid\":\"<USER_ID>\", \"password\":\"<PASS_WORD>\"}' http://115.23.164.167:31088/moim/api/v0/auth/login | grep -oP 'ACCESS_TOKEN: \\K.*'"
+                )
+                .version("v0.0");
+
+        Server local = new Server().url("http://localhost:8080/").description("LOCAL");
+        Server dev = new Server().url("http://115.23.164.167:31088/moim").description("DEV");
+        List<Server> servers = List.of(local, dev);
+
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER).name("Authorization");
+        SecurityRequirement securityItem = new SecurityRequirement().addList("bearerAuth");
+
         return new OpenAPI()
-//                .addServersItem(new Server().url("https://dev.user.gocho-back.com/").description("USER - DEV"))
-                .addServersItem(new Server().url("http://localhost:8080/").description("LOCAL"))
-                .info(new Info().title("Moiming Devs API 명세서")
-                        .description("### 에러코드 문서\n\n" +
-                                "https://docs.google.com/spreadsheets/d/1vkgXTrdumMbzeeNeGzC8MvOdo3CQGqyr/edit?usp=share_link&ouid=115296106035275739943&rtpof=true&sd=true\n\n" +
-                                "### 하기 문서의 모든 응답 Example Value 는 {\"data\":[Example Value]} 값으로 묶여있는 JSON 값입니다\n\n" +
-                                "**`Error Response Model`**\n\n" +
-                                "- errorCode : 에러코드명, 에러코드 문서에 명시되어 있습니다\n" +
-                                "- errorType : 에러 현황을 간략하게 알 수 있는 타입 값이 전달됩니다. 에러코드 문서에 명시되어 있습니다\n" +
-                                "- errorDesc : 서버에서 발생한 error exception 의 메세지를 전달합니다.")
-                        .version("v0.0"));
+                .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
+                .addSecurityItem(securityItem)
+                .servers(servers)
+                .info(info);
     }
 
     @Bean

--- a/src/main/java/com/peoplein/moiming/config/SwaggerConfiguration.java
+++ b/src/main/java/com/peoplein/moiming/config/SwaggerConfiguration.java
@@ -29,12 +29,12 @@ public class SwaggerConfiguration {
                         "- errorType : 에러 현황을 간략하게 알 수 있는 타입 값이 전달됩니다. 에러코드 문서에 명시되어 있습니다\n" +
                         "- errorDesc : 서버에서 발생한 error exception 의 메세지를 전달합니다.\n\n\n" +
                         "**`Execute 실행 시, JWT 토큰을 Authorize에서 포함하세요`**\n" +
-                        "- curl -X POST -H \"Content-Type: application/json\" -d '{\"uid\":\"<USER_ID>\", \"password\":\"<PASS_WORD>\"}' http://115.23.164.167:31088/moim/api/v0/auth/login | grep -oP 'ACCESS_TOKEN: \\K.*'"
+                        "- curl -X POST -i -H \"Content-Type: application/json\" -d '{\"uid\":\"<USER_ID>\", \"password\":\"<PASS_WORD>\"}' http://moim.k8s-sha.com:31088/api/v0/auth/login | grep -i \"^access_token:\" | awk -F': ' '{print $2}' | tr -d '\\r'"
                 )
                 .version("v0.0");
 
         Server local = new Server().url("http://localhost:8080/").description("LOCAL");
-        Server dev = new Server().url("http://115.23.164.167:31088/moim").description("DEV");
+        Server dev = new Server().url("http://moim.k8s-sha.com:31088/").description("DEV");
         List<Server> servers = List.of(local, dev);
 
         SecurityScheme securityScheme = new SecurityScheme()
@@ -47,7 +47,6 @@ public class SwaggerConfiguration {
                 .addSecurityItem(securityItem)
                 .servers(servers)
                 .info(info);
-    }
 
     @Bean
     public GroupedOpenApi groupedOpenApi() {

--- a/src/main/java/com/peoplein/moiming/security/SecurityJwtConfig.java
+++ b/src/main/java/com/peoplein/moiming/security/SecurityJwtConfig.java
@@ -99,7 +99,10 @@ public class SecurityJwtConfig extends WebSecurityConfigurerAdapter {
          *  2. 현재 그 외는 인증시 가능
          */
         http
-                .antMatcher("/swagger-ui")
+                .antMatcher("/swagger-ui/**")
+                .antMatcher("classpath:/META-INF/resources/webjars/swagger-ui/**")
+                .antMatcher("/**")
+                .antMatcher("/v3/api-docs/**").anonymous()
         ;
 
         http


### PR DESCRIPTION
## Swagger USE JWT Token for API Request
- Swagger에서 요청할 수 있는 웹 서버를 추가했습니다. 계속 localhost로 보내서 문제가 되었습니다.
- Swagger에서 요청할 때, JWT 로그인 토큰을 추가해서 보낼 수 있도록 수정했습니다. Spring Security에서 반드시 JWT 토큰을 요청하기 때문에 Swagger에서도 execute를 할 때 JWT 로그인 토큰을 무적권 보내야 합니다. 
- JWT 로그인 토큰은 Swagger에서 자동으로 얻어줄 수 없는 것 같습니다. 그래서 프론트 분들이 손쉽게 JWT 토큰 얻을 수 있도록, curl 커맨드를 문서에 기록했습니다.