### PR TITLE
Fileupload 1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,13 @@ dependencies {
     testRuntimeOnly 'com.mysql:mysql-connector-j'
 //	untimeOnly 'com.mysql:mysql-connector-j'
 
+    // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator:2.7.6'
+    // https://mvnrepository.com/artifact/io.micrometer/micrometer-registry-prometheus
+    implementation 'io.micrometer:micrometer-registry-prometheus:1.11.2'
+
+
+
 }
 
 tasks.named('test') {

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -5,7 +5,7 @@ pushd ..
 gradle clean
 gradle build -x test
 
-docker buildx build --platform linux/arm64 --push -t 0612sha/moim:arm64.latest .
+docker buildx build --platform linux/arm64 --push -t 0612sha/moim-arm64:latest .
 rm moiming.jar
 
 

--- a/src/main/java/com/peoplein/moiming/MoimingApplication.java
+++ b/src/main/java/com/peoplein/moiming/MoimingApplication.java
@@ -10,12 +10,14 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
 @SpringBootApplication
+@EnableScheduling
 public class MoimingApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/peoplein/moiming/controller/FileTestController.java
+++ b/src/main/java/com/peoplein/moiming/controller/FileTestController.java
@@ -1,2 +1,37 @@
-package com.peoplein.moiming.controller;public class FileTestController {
+package com.peoplein.moiming.controller;
+
+import com.peoplein.moiming.service.FileService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+public class FileTestController {
+
+    private final FileService service;
+
+    @PostMapping("/test-file/up")
+    public String uploadFile(@RequestParam(name = "uploadFile") List<MultipartFile> file, Long id) throws IOException {
+        if (file != null) {
+            log.info("save file. id = {}, size = {}", id, file.size());
+            service.saveFile(id, file);
+        }
+        return "ok";
+    }
+
+    @PostMapping("/test-file/del")
+    public String deleteFile(Long id) {
+        if (id != null) {
+            service.removeFile(id);
+        }
+        return "ok";
+    }
+
 }

--- a/src/main/java/com/peoplein/moiming/controller/FileTestController.java
+++ b/src/main/java/com/peoplein/moiming/controller/FileTestController.java
@@ -1,0 +1,2 @@
+package com.peoplein.moiming.controller;public class FileTestController {
+}

--- a/src/main/java/com/peoplein/moiming/cron/FileDeleteScheduler.java
+++ b/src/main/java/com/peoplein/moiming/cron/FileDeleteScheduler.java
@@ -1,2 +1,56 @@
-package com.peoplein.moiming.cron;public class FileDeleteScheduler {
+package com.peoplein.moiming.cron;
+
+import com.peoplein.moiming.domain.FileUpload;
+import com.peoplein.moiming.repository.FileUploadRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FileDeleteScheduler {
+    private final FileUploadRepository fileUploadRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 */1 * * * *")
+    public void delete() {
+        log.info("FileDeletedScheduler Called");
+        List<FileUpload> allDeletedMarkedFile = fileUploadRepository.findAllDeletedMarkedFile();
+        List<String> filePath = allDeletedMarkedFile.stream()
+                .map(FileUpload::getSavedFileName)
+                .collect(Collectors.toList());
+
+        deleteFiles(filePath);
+
+        List<Long> deletedFieldId = allDeletedMarkedFile.stream()
+                .map(FileUpload::getId)
+                .collect(Collectors.toList());
+
+        fileUploadRepository.removeFiles(deletedFieldId);
+        log.info("FileDeletedScheduler Called. delete file count = {}", deletedFieldId.size());
+    }
+
+    private void deleteFiles(List<String> filePath) {
+        filePath.forEach(this::deleteFile);
+    }
+
+    private void deleteFile(String filePath) {
+        Path path = Paths.get(filePath);
+        try {
+            Files.delete(path);
+        } catch (IOException e) {
+            log.warn("fail to delete this file {}. it may be delete already", filePath);
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/src/main/java/com/peoplein/moiming/cron/FileDeleteScheduler.java
+++ b/src/main/java/com/peoplein/moiming/cron/FileDeleteScheduler.java
@@ -1,0 +1,2 @@
+package com.peoplein.moiming.cron;public class FileDeleteScheduler {
+}

--- a/src/main/java/com/peoplein/moiming/cron/FileDeleteScheduler.java
+++ b/src/main/java/com/peoplein/moiming/cron/FileDeleteScheduler.java
@@ -23,6 +23,7 @@ public class FileDeleteScheduler {
 
     @Transactional
     @Scheduled(cron = "0 */1 * * * *")
+//    @Scheduled(cron = "0 */1 * * * *")
     public void delete() {
         log.info("FileDeletedScheduler Called");
         List<FileUpload> allDeletedMarkedFile = fileUploadRepository.findAllDeletedMarkedFile();

--- a/src/main/java/com/peoplein/moiming/domain/FileUpload.java
+++ b/src/main/java/com/peoplein/moiming/domain/FileUpload.java
@@ -21,19 +21,28 @@ public class FileUpload extends BaseEntity{
     @Column(name = "file_id")
     private Long id;
 
-    private FileUpload(String originalFileName, String savedFileName) {
+    private FileUpload(String originalFileName, String savedFileName, Long ownerKey) {
         this.originalFileName = originalFileName;
         this.savedFileName = savedFileName;
+        this.ownerKey = ownerKey;
+        this.isDeleted = false;
     }
 
     @Column(unique = true)
     private String savedFileName;
     private String originalFileName;
+    private Long ownerKey;
+    private boolean isDeleted;
 
 
-    public static FileUpload createFileUpload(String originalFileName, String fileDir) {
+    public static FileUpload createFileUpload(String originalFileName, String fileDir, Long ownerKey) {
         String uuid = UUID.randomUUID().toString();
         String uploadFileName = String.format("%s/%s-%s", fileDir, uuid, originalFileName);
-        return new FileUpload(originalFileName, uploadFileName);
+        return new FileUpload(originalFileName, uploadFileName, ownerKey);
     }
+
+    public void markDeleted() {
+        this.isDeleted = true;
+    }
+
 }

--- a/src/main/java/com/peoplein/moiming/domain/FileUpload.java
+++ b/src/main/java/com/peoplein/moiming/domain/FileUpload.java
@@ -1,0 +1,39 @@
+package com.peoplein.moiming.domain;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FileUpload extends BaseEntity{
+
+    @Id
+    @GeneratedValue
+    @Column(name = "file_id")
+    private Long id;
+
+    private FileUpload(String originalFileName, String savedFileName) {
+        this.originalFileName = originalFileName;
+        this.savedFileName = savedFileName;
+    }
+
+    @Column(unique = true)
+    private String savedFileName;
+    private String originalFileName;
+
+
+    public static FileUpload createFileUpload(String originalFileName, String fileDir) {
+        String uuid = UUID.randomUUID().toString();
+        String uploadFileName = String.format("%s/%s-%s", fileDir, uuid, originalFileName);
+        return new FileUpload(originalFileName, uploadFileName);
+    }
+}

--- a/src/main/java/com/peoplein/moiming/repository/FileUploadRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/FileUploadRepository.java
@@ -1,0 +1,2 @@
+package com.peoplein.moiming.repository;public class FileUploadRepository {
+}

--- a/src/main/java/com/peoplein/moiming/repository/FileUploadRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/FileUploadRepository.java
@@ -1,2 +1,17 @@
-package com.peoplein.moiming.repository;public class FileUploadRepository {
+package com.peoplein.moiming.repository;
+
+import com.peoplein.moiming.domain.FileUpload;
+
+import java.util.List;
+
+public interface FileUploadRepository {
+
+    Long saveFile(FileUpload fileUpload);
+    List<FileUpload> findFileUploadByOwnerPk(Long pk);
+
+    void removeFiles(List<Long> fileIds);
+
+    List<FileUpload> findAllDeletedMarkedFile();
+
+
 }

--- a/src/main/java/com/peoplein/moiming/repository/jpa/FileUploadJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/FileUploadJpaRepository.java
@@ -1,0 +1,47 @@
+package com.peoplein.moiming.repository.jpa.query;
+
+import com.peoplein.moiming.domain.FileUpload;
+import com.peoplein.moiming.domain.QFileUpload;
+import com.peoplein.moiming.repository.FileUploadRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static com.peoplein.moiming.domain.QFileUpload.*;
+
+@Repository
+public class FileUploadJpaRepository implements FileUploadRepository {
+
+    private final EntityManager em;
+    private final JPAQueryFactory queryFactory;
+
+
+    public FileUploadJpaRepository(EntityManager em, JPAQueryFactory queryFactory) {
+        this.em = em;
+        this.queryFactory = queryFactory;
+    }
+
+    @Override
+    public Long saveFile(FileUpload fileUpload) {
+        em.persist(fileUpload);
+        return fileUpload.getId();
+    }
+
+    @Override
+    public List<FileUpload> findFileUploadByOwnerPk(Long pk) {
+        return queryFactory
+                .selectFrom(fileUpload)
+                .where(fileUpload.id.eq(pk))
+                .fetch();
+    }
+
+    @Override
+    public void removeFiles(List<Long> fileIds) {
+        queryFactory
+                .delete(fileUpload)
+                .where(fileUpload.id.in(fileIds))
+                .execute();
+    }
+}

--- a/src/main/java/com/peoplein/moiming/repository/jpa/FileUploadJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/FileUploadJpaRepository.java
@@ -1,4 +1,4 @@
-package com.peoplein.moiming.repository.jpa.query;
+package com.peoplein.moiming.repository.jpa;
 
 import com.peoplein.moiming.domain.FileUpload;
 import com.peoplein.moiming.domain.QFileUpload;
@@ -33,7 +33,7 @@ public class FileUploadJpaRepository implements FileUploadRepository {
     public List<FileUpload> findFileUploadByOwnerPk(Long pk) {
         return queryFactory
                 .selectFrom(fileUpload)
-                .where(fileUpload.id.eq(pk))
+                .where(fileUpload.ownerKey.eq(pk))
                 .fetch();
     }
 
@@ -43,5 +43,13 @@ public class FileUploadJpaRepository implements FileUploadRepository {
                 .delete(fileUpload)
                 .where(fileUpload.id.in(fileIds))
                 .execute();
+    }
+
+    @Override
+    public List<FileUpload> findAllDeletedMarkedFile() {
+        return queryFactory
+                .selectFrom(fileUpload)
+                .where(fileUpload.isDeleted.eq(true))
+                .fetch();
     }
 }

--- a/src/main/java/com/peoplein/moiming/security/SecurityJwtConfig.java
+++ b/src/main/java/com/peoplein/moiming/security/SecurityJwtConfig.java
@@ -102,6 +102,7 @@ public class SecurityJwtConfig extends WebSecurityConfigurerAdapter {
                 .antMatcher("/swagger-ui/**")
                 .antMatcher("classpath:/META-INF/resources/webjars/swagger-ui/**")
                 .antMatcher("/**")
+                .antMatcher("/test-file/**")
                 .antMatcher("/v3/api-docs/**").anonymous()
         ;
 

--- a/src/main/java/com/peoplein/moiming/service/FileService.java
+++ b/src/main/java/com/peoplein/moiming/service/FileService.java
@@ -1,0 +1,2 @@
+package com.peoplein.moiming.service;public class FileService {
+}

--- a/src/main/java/com/peoplein/moiming/service/FileService.java
+++ b/src/main/java/com/peoplein/moiming/service/FileService.java
@@ -1,2 +1,120 @@
-package com.peoplein.moiming.service;public class FileService {
+package com.peoplein.moiming.service;
+
+import com.peoplein.moiming.cron.FileDeleteScheduler;
+import com.peoplein.moiming.domain.FileUpload;
+import com.peoplein.moiming.repository.FileUploadRepository;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+public class FileService {
+
+    private static final String JPG_CONTENT_TYPE = "image/jpeg";
+    private static final String PNG_CONTENT_TYPE = "image/png";
+    private final Pattern PATTERN_PROPER_SUFFIX;
+    private final Pattern PATTERN_FORBIDDEN_PREFIX;
+    private final FileUploadRepository fileUploadRepository;
+    private final FileDeleteScheduler scheduler;
+
+
+    @Value("${file.dir}")
+    private String fileDir;
+
+    public FileService(FileUploadRepository fileUploadRepository, FileDeleteScheduler scheduler) {
+        this.PATTERN_FORBIDDEN_PREFIX = Pattern.compile("^\\.\\.\\/.*");
+        this.PATTERN_PROPER_SUFFIX = Pattern.compile(".+.(jpeg|jpg|PNG|png)$");
+        this.fileUploadRepository = fileUploadRepository;
+        this.scheduler = scheduler;
+    }
+
+    // File Invalid 시, RuntimeException 발생. -> 전체 트랜잭션 롤백 유도.
+    // 트랜잭션 전파 시, 부모 트랜잭션에서 자동 롤백.
+    // 부모 트랜잭션에서 이 메서드 호출 후, 롤백 발생할 수 있음. 따라서 이 녀석은 부모 트랜잭션에서도 가장 마지막에 호출되어야 함.
+    @Transactional
+    public boolean saveFile(Long ownerKey, List<MultipartFile> files) throws IOException {
+
+        areTheyProper(files);
+
+        final List<TupleMultiPartFile> tupleMultiPartFiles = files.stream()
+                .map(multipartFile -> new TupleMultiPartFile(multipartFile, fileDir, ownerKey))
+                .collect(Collectors.toList());
+
+        tupleMultiPartFiles.forEach(tupleMultiPartFile -> fileUploadRepository.saveFile(tupleMultiPartFile.getFileUpload()));
+
+        for (TupleMultiPartFile tupleMultiPartFile : tupleMultiPartFiles) {
+            final MultipartFile multipartFile = tupleMultiPartFile.getMultipartFile();
+            multipartFile.transferTo(tupleMultiPartFile.getFile());
+            log.info("디스크에 파일 저장 완료 = {}", tupleMultiPartFile.getFileUpload().getSavedFileName());
+        }
+
+        return true;
+    }
+
+
+    @Transactional
+    public void removeFile(Long ownerPk) {
+        final List<FileUpload> fileUploadByOwnerPk = fileUploadRepository.findFileUploadByOwnerPk(ownerPk);
+        // mark deleted by dirty check.
+        fileUploadByOwnerPk.forEach(FileUpload::markDeleted);
+    }
+
+    private void areTheyProper(List<MultipartFile> files) {
+        List<MultipartFile> multipartFiles = files.stream()
+                .filter(file -> !hasEmptyFile(file.getOriginalFilename()))
+                .filter(file -> hasProperType(file.getContentType()))
+                .filter(file -> hasProperTypePerspectiveSuffix(file.getOriginalFilename()))
+                .filter(file -> hasProperName(file.getOriginalFilename()))
+                .collect(Collectors.toList());
+
+        if (multipartFiles.size() != files.size()) {
+            throw new RuntimeException("uploaded file invalid.");
+        }
+    }
+
+    private boolean hasEmptyFile(String originalFilename) {
+        return !StringUtils.hasText(originalFilename);
+    }
+
+    private boolean hasProperName(String fileName) {
+        return !PATTERN_FORBIDDEN_PREFIX
+                .matcher(fileName)
+                .matches();
+    }
+
+    private boolean hasProperType(String contentType) {
+        return (contentType.equals(JPG_CONTENT_TYPE)) ||
+                (contentType.equals(PNG_CONTENT_TYPE));
+    }
+
+    private boolean hasProperTypePerspectiveSuffix(String fileName) {
+        return PATTERN_PROPER_SUFFIX
+                .matcher(fileName)
+                .matches();
+    }
+
+    @Getter
+    static class TupleMultiPartFile{
+        private final MultipartFile multipartFile;
+        private final File file;
+        private final FileUpload fileUpload;
+
+
+        public TupleMultiPartFile(MultipartFile multipartFile, String fileDir, Long ownerKey) {
+            this.multipartFile = multipartFile;
+            this.fileUpload = FileUpload.createFileUpload(multipartFile.getOriginalFilename(), fileDir, ownerKey);
+            this.file = new File(fileUpload.getSavedFileName());
+        }
+    }
 }

--- a/src/main/java/com/peoplein/moiming/service/FileTransactionService.java
+++ b/src/main/java/com/peoplein/moiming/service/FileTransactionService.java
@@ -2,6 +2,7 @@ package com.peoplein.moiming.service;
 
 import com.peoplein.moiming.domain.FileUpload;
 import com.peoplein.moiming.repository.FileUploadRepository;
+import com.peoplein.moiming.service.util.TupleMultiPartFile;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,7 +18,7 @@ public class FileTransactionService {
 
     private final FileUploadRepository fileUploadRepository;
 
-    public void saveFileToDB(List<FileService.TupleMultiPartFile> tupleMultiPartFiles) {
+    public void saveFileToDB(List<TupleMultiPartFile> tupleMultiPartFiles) {
         tupleMultiPartFiles.forEach(tupleMultiPartFile -> fileUploadRepository.saveFile(tupleMultiPartFile.getFileUpload()));
     }
 

--- a/src/main/java/com/peoplein/moiming/service/FileTransactionService.java
+++ b/src/main/java/com/peoplein/moiming/service/FileTransactionService.java
@@ -1,2 +1,29 @@
-package com.peoplein.moiming.service;public class FileTransactionService {
+package com.peoplein.moiming.service;
+
+import com.peoplein.moiming.domain.FileUpload;
+import com.peoplein.moiming.repository.FileUploadRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FileTransactionService {
+
+    private final FileUploadRepository fileUploadRepository;
+
+    public void saveFileToDB(List<FileService.TupleMultiPartFile> tupleMultiPartFiles) {
+        tupleMultiPartFiles.forEach(tupleMultiPartFile -> fileUploadRepository.saveFile(tupleMultiPartFile.getFileUpload()));
+    }
+
+    public void removeFile(Long ownerPk) {
+        final List<FileUpload> fileUploadByOwnerPk = fileUploadRepository.findFileUploadByOwnerPk(ownerPk);
+        // mark deleted by dirty check.
+        fileUploadByOwnerPk.forEach(FileUpload::markDeleted);
+    }
 }

--- a/src/main/java/com/peoplein/moiming/service/FileTransactionService.java
+++ b/src/main/java/com/peoplein/moiming/service/FileTransactionService.java
@@ -1,0 +1,2 @@
+package com.peoplein.moiming.service;public class FileTransactionService {
+}

--- a/src/main/java/com/peoplein/moiming/service/util/FilePersistor.java
+++ b/src/main/java/com/peoplein/moiming/service/util/FilePersistor.java
@@ -1,0 +1,10 @@
+package com.peoplein.moiming.service.util;
+
+
+import java.util.List;
+
+public interface FilePersistor {
+
+    boolean persistFiles(List<TupleMultiPartFile> files);
+
+}

--- a/src/main/java/com/peoplein/moiming/service/util/LocalFilePersistor.java
+++ b/src/main/java/com/peoplein/moiming/service/util/LocalFilePersistor.java
@@ -1,0 +1,31 @@
+package com.peoplein.moiming.service.util;
+
+import com.peoplein.moiming.service.FileService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@Component
+public class LocalFilePersistor implements FilePersistor{
+    @Override
+    public boolean persistFiles(List<TupleMultiPartFile> files){
+
+        for (TupleMultiPartFile tupleMultiPartFile : files) {
+            final MultipartFile multipartFile = tupleMultiPartFile.getMultipartFile();
+
+            try {
+                multipartFile.transferTo(tupleMultiPartFile.getFile());
+            } catch (IOException e) {
+                log.error("file 저장 실패 = {}", multipartFile.getOriginalFilename());
+                return false;
+            }
+
+            log.info("디스크에 파일 저장 완료 = {}", tupleMultiPartFile.getFileUpload().getSavedFileName());
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/peoplein/moiming/service/util/TupleMultiPartFile.java
+++ b/src/main/java/com/peoplein/moiming/service/util/TupleMultiPartFile.java
@@ -1,0 +1,21 @@
+package com.peoplein.moiming.service.util;
+
+import com.peoplein.moiming.domain.FileUpload;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+
+@Getter
+public class TupleMultiPartFile{
+    private final MultipartFile multipartFile;
+    private final File file;
+    private final FileUpload fileUpload;
+
+
+    public TupleMultiPartFile(MultipartFile multipartFile, String fileDir, Long ownerKey) {
+        this.multipartFile = multipartFile;
+        this.fileUpload = FileUpload.createFileUpload(multipartFile.getOriginalFilename(), fileDir, ownerKey);
+        this.file = new File(fileUpload.getSavedFileName());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,11 +9,11 @@ spring:
 
   #DB
   #Local DB Source
-  datasource:
-    url: jdbc:mysql://localhost:3306/moiming_dev_db?useSSL=false&useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
-    username: root
-    password: peoplein
-    driver-class-name: com.mysql.cj.jdbc.Driver
+#  datasource:
+#    url: jdbc:mysql://localhost:3306/moiming_dev_db?useSSL=false&useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+#    username: root
+#    password: peoplein
+#    driver-class-name: com.mysql.cj.jdbc.Driver
 
     #Test Server Source
 #      url: jdbc:mysql://dev-database:3306/moiming_dev_db?useSSL=false&useUnicode=true&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
@@ -23,9 +23,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
-    database: mysql
+#    database: mysql
     properties:
-      dialect: org.hibernate.dialect.MySQL5InnoDBDialect
+#      dialect: org.hibernate.dialect.MySQL5InnoDBDialect
       hibernate:
         show_sql: true
         format_sql: true
@@ -42,3 +42,5 @@ open_api_keys:
   naver_access_key_id: rJNU8kRQi1b4Z9QFrCKK
   naver_secret_key_id: 2z0LxdrRcqMCWgADLCTnwlw6SnlYV6YmYK5Z8zzk
 
+
+file.dir: C:/dev/230715/demo

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,9 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "prometheus,health,metrics"
+
 spring:
   profiles:
     active: production

--- a/src/test/java/com/peoplein/moiming/service/FileServiceTest.java
+++ b/src/test/java/com/peoplein/moiming/service/FileServiceTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class FileServiceTest {
+  
+}

--- a/src/test/java/com/peoplein/moiming/service/FileServiceTest.java
+++ b/src/test/java/com/peoplein/moiming/service/FileServiceTest.java
@@ -1,11 +1,14 @@
 package com.peoplein.moiming.service;
 
 import com.peoplein.moiming.BaseTest;
-import org.assertj.core.api.Assertions;
+import com.peoplein.moiming.service.util.FilePersistor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -15,13 +18,25 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 @SpringBootTest
+@Import(FileServiceTest.TestConfig.class)
 class FileServiceTest extends BaseTest {
 
     @Autowired
     FileService fileService;
 
+    @TestConfiguration
+    static class TestConfig{
+
+        @Bean
+        public FilePersistor filePersistor() {
+            FilePersistor mockPersistor = mock(FilePersistor.class);
+            when(mockPersistor.persistFiles(any())).thenReturn(true);
+            return mockPersistor;
+        }
+    }
 
     @Test
     @DisplayName("success")

--- a/src/test/java/com/peoplein/moiming/service/FileServiceTest.java
+++ b/src/test/java/com/peoplein/moiming/service/FileServiceTest.java
@@ -1,4 +1,70 @@
+package com.peoplein.moiming.service;
+
+import com.peoplein.moiming.BaseTest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
-class FileServiceTest {
-  
+
+@SpringBootTest
+class FileServiceTest extends BaseTest {
+
+    @Autowired
+    FileService fileService;
+
+
+    @Test
+    @DisplayName("success")
+    void test1() throws IOException {
+        // GIVEN :
+        MultipartFile multipartFile1 = new MockMultipartFile("3.jpg", "3.jpg", "image/jpeg", new byte[]{});
+        MultipartFile multipartFile2 = new MockMultipartFile("3.PNG", "3.PNG", "image/png", new byte[]{});
+        List<MultipartFile> files = List.of(multipartFile1, multipartFile2);
+        Long ownerKey = 1L;
+
+        // WHEN :
+        boolean result = fileService.saveFile(ownerKey, files);
+
+        // THEN
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("fail because of wrong inputName")
+    void test2() throws IOException {
+        // GIVEN :
+        MultipartFile multipartFile1 = new MockMultipartFile("3.img", "3.img", "image/jpeg", new byte[]{});
+        MultipartFile multipartFile2 = new MockMultipartFile("3.PNG", "3.PNG", "image/png", new byte[]{});
+        List<MultipartFile> files = List.of(multipartFile1, multipartFile2);
+        Long ownerKey = 1L;
+
+        // WHEN + THEN:
+        assertThatThrownBy(() -> fileService.saveFile(ownerKey, files))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    @DisplayName("fail because of wrong contentType")
+    void test3() {
+        // GIVEN :
+        MultipartFile multipartFile1 = new MockMultipartFile("3.jpg", "3.jpg", "json", new byte[]{});
+        MultipartFile multipartFile2 = new MockMultipartFile("3.PNG", "3.PNG", "image/png", new byte[]{});
+        List<MultipartFile> files = List.of(multipartFile1, multipartFile2);
+        Long ownerKey = 1L;
+
+        // WHEN + THEN:
+        assertThatThrownBy(() -> fileService.saveFile(ownerKey, files))
+                .isInstanceOf(RuntimeException.class);
+
+    }
+
 }

--- a/src/test/java/com/peoplein/moiming/service/FileServiceTest.java
+++ b/src/test/java/com/peoplein/moiming/service/FileServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -24,6 +25,7 @@ class FileServiceTest extends BaseTest {
 
     @Test
     @DisplayName("success")
+    @Transactional
     void test1() throws IOException {
         // GIVEN :
         MultipartFile multipartFile1 = new MockMultipartFile("3.jpg", "3.jpg", "image/jpeg", new byte[]{});

--- a/src/test/java/com/peoplein/moiming/service/FileServiceTest.java
+++ b/src/test/java/com/peoplein/moiming/service/FileServiceTest.java
@@ -21,7 +21,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @SpringBootTest
-@Import(FileServiceTest.TestConfig.class)
 class FileServiceTest extends BaseTest {
 
     @Autowired

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -28,3 +28,5 @@ open_api_keys:
   naver_sens_sms: ncp:sms:kr:307383565992:moiming_phone_certi
   naver_access_key_id: rJNU8kRQi1b4Z9QFrCKK
   naver_secret_key_id: 2z0LxdrRcqMCWgADLCTnwlw6SnlYV6YmYK5Z8zzk
+
+file.dir: C:/dev/230715/demo


### PR DESCRIPTION
### FileUpload 도메인 추가
- File이 서버에 올려졌을 때, 같은 이름을 가지는 경우가 있을 수 있습니다. 이걸 해결하기 위해 Hash 값을 붙여서 파일 이름을 재정의해줍니다.
- 재정의 된 파일은 FileUpload 객체로 만들어져 DB에 저장됩니다. 누가 올린 파일인지 알고 반환해줘야 하기 때문입니다.

### FileUploadRepository 추가
- FileUpload 기능 구현에 필요한 쿼리를 작성했습니다.

### FileService 구현
- FileService 클래스를 구현했습니다. 파일 업로드가 필요한 클래스에서는 이 서비스를 주입 받아서 사용하면 됩니다. 
- 사용할 때는 반드시 이렇게 사용해야합니다.
- 1. 사용하는 쪽에서는 트랜잭션을 시작하지 않은 상태로 saveFile() 호출
- 2. saveFile() 호출이 끝난 후 트랜잭션 사용 

