### PR TITLE
모임별 조회수 구현

### DIFF
--- a/src/main/java/com/peoplein/moiming/MoimingApplication.java
+++ b/src/main/java/com/peoplein/moiming/MoimingApplication.java
@@ -2,11 +2,13 @@ package com.peoplein.moiming;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 
 @SpringBootApplication
 @EnableScheduling
+@EnableAsync
 public class MoimingApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/peoplein/moiming/cron/MoimCounterUpdateScheduler.java
+++ b/src/main/java/com/peoplein/moiming/cron/MoimCounterUpdateScheduler.java
@@ -1,0 +1,26 @@
+package com.peoplein.moiming.cron;
+
+import com.peoplein.moiming.service.MemberMoimCounterService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MoimCounterUpdateScheduler {
+    private final MemberMoimCounterService memberMoimCounterService;
+
+    @Scheduled(cron = "0 */10 * * * *")
+    public void update() {
+        log.info("MoimCounterUpdateScheduler started update.");
+        memberMoimCounterService.update();
+    }
+
+    @Scheduled(cron = "0 * */12 * * *")
+    public void delete() {
+        log.info("MoimCounterUpdateScheduler started deleted.");
+        memberMoimCounterService.deleteDoesNotExistMoim();
+    }
+}

--- a/src/main/java/com/peoplein/moiming/domain/MemberMoimCounter.java
+++ b/src/main/java/com/peoplein/moiming/domain/MemberMoimCounter.java
@@ -1,0 +1,44 @@
+package com.peoplein.moiming.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberMoimCounter {
+
+    @Id
+    @Column(name = "member_moim_counter_id")
+    @GeneratedValue
+    private Long id;
+
+    private Long memberId;
+
+    private Long moimId;
+
+    private LocalDate visitDate;
+
+    private MemberMoimCounter(Long memberId, Long moimId, LocalDate visitDate) {
+        this.memberId = memberId;
+        this.moimId = moimId;
+        this.visitDate = visitDate;
+    }
+
+    public static MemberMoimCounter create(long memberId, long moimId, LocalDate visitDate) {
+        if (visitDate == null)
+            throw new IllegalArgumentException(String.format("wrong input. MemberId = {}, MoimId = {}, visitDate = {}",
+                    memberId, moimId, visitDate));
+        return new MemberMoimCounter(memberId, moimId, visitDate);
+    }
+
+}

--- a/src/main/java/com/peoplein/moiming/domain/MemberMoimMaterializedView.java
+++ b/src/main/java/com/peoplein/moiming/domain/MemberMoimMaterializedView.java
@@ -1,0 +1,40 @@
+package com.peoplein.moiming.domain;
+
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberMoimMaterializedView {
+
+
+    @Id
+    @Column(name = "member_moim_materialized_view_id")
+    @GeneratedValue
+    private Long id;
+
+    private Long count;
+    private Long moimId; // Moim 객체를 같이 줘야할 듯? 다 필요는 없을 것 같고. 여기서 in 몇개만 찾아내서 주면 될 듯. ㅇㅇ..
+
+    private MemberMoimMaterializedView(Long count, Long moimId) {
+        this.count = count;
+        this.moimId = moimId;
+    }
+
+    public void updateCount(Long count) {
+        this.count = count;
+    }
+
+
+    public static MemberMoimMaterializedView create(Long count, Long moimId) {
+        return new MemberMoimMaterializedView(count, moimId);
+    }
+}

--- a/src/main/java/com/peoplein/moiming/event/MemberMoimCounterEvent.java
+++ b/src/main/java/com/peoplein/moiming/event/MemberMoimCounterEvent.java
@@ -1,0 +1,23 @@
+package com.peoplein.moiming.event;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class MemberMoimCounterEvent {
+
+    private final Long memberId;
+    private final Long moimId;
+    private final LocalDate visitDated;
+
+    private MemberMoimCounterEvent(Long memberId, Long moimId, LocalDate visitDated) {
+        this.memberId = memberId;
+        this.moimId = moimId;
+        this.visitDated = visitDated;
+    }
+
+    public static MemberMoimCounterEvent create(Long memberId, Long moimId, LocalDate visitDated) {
+        return new MemberMoimCounterEvent(memberId, moimId, visitDated);
+    }
+}

--- a/src/main/java/com/peoplein/moiming/event/MemberMoimCounterEventListener.java
+++ b/src/main/java/com/peoplein/moiming/event/MemberMoimCounterEventListener.java
@@ -1,0 +1,24 @@
+package com.peoplein.moiming.event;
+
+import com.peoplein.moiming.service.MemberMoimCounterService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Async
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MemberMoimCounterEventListener {
+    private final MemberMoimCounterService memberMoimCounterService;
+
+    @EventListener
+    public void handleEvent(MemberMoimCounterEvent event) {
+        log.info("event execute = {}", event);
+        memberMoimCounterService.create(event.getMemberId(), event.getMoimId(), LocalDate.now());
+    }
+}

--- a/src/main/java/com/peoplein/moiming/repository/MemberMoimCounterRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/MemberMoimCounterRepository.java
@@ -1,0 +1,15 @@
+package com.peoplein.moiming.repository;
+
+import com.peoplein.moiming.domain.MemberMoimCounter;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface MemberMoimCounterRepository {
+
+    void save(MemberMoimCounter memberMoimCounter);
+    Optional<MemberMoimCounter> findBy(Long memberId, Long moimId, LocalDate date);
+    boolean acquireLock(String lockName);
+    void releaseLock(String lockName);
+
+}

--- a/src/main/java/com/peoplein/moiming/repository/MemberMoimCounterRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/MemberMoimCounterRepository.java
@@ -1,8 +1,10 @@
 package com.peoplein.moiming.repository;
 
 import com.peoplein.moiming.domain.MemberMoimCounter;
+import lombok.Getter;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberMoimCounterRepository {
@@ -11,5 +13,18 @@ public interface MemberMoimCounterRepository {
     Optional<MemberMoimCounter> findBy(Long memberId, Long moimId, LocalDate date);
     boolean acquireLock(String lockName);
     void releaseLock(String lockName);
+    List<MoimViewCountTuple> findByGroupByMoimId();
+    void deleteByMoimIds(List<Long> moimIds);
+
+    @Getter
+    class MoimViewCountTuple {
+        private final Long moimId;
+        private final Long viewCount;
+
+        public MoimViewCountTuple(Long moimId, Long viewCount) {
+            this.moimId = moimId;
+            this.viewCount = viewCount;
+        }
+    }
 
 }

--- a/src/main/java/com/peoplein/moiming/repository/MemberMoimMaterializedViewRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/MemberMoimMaterializedViewRepository.java
@@ -1,0 +1,13 @@
+package com.peoplein.moiming.repository;
+
+import com.peoplein.moiming.domain.MemberMoimMaterializedView;
+
+import java.util.List;
+
+public interface MemberMoimMaterializedViewRepository {
+
+    Long save(MemberMoimMaterializedView memberMoimMaterializedView);
+    List<MemberMoimMaterializedView> findByMoimIds(List<Long> moimIds);
+    List<MemberMoimMaterializedView> findAll();
+    void deleteMViews(List<Long> moimIds);
+}

--- a/src/main/java/com/peoplein/moiming/repository/jpa/MemberMoimCounterJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/MemberMoimCounterJpaRepository.java
@@ -1,8 +1,8 @@
 package com.peoplein.moiming.repository.jpa;
 
 import com.peoplein.moiming.domain.MemberMoimCounter;
-import com.peoplein.moiming.domain.QMemberMoimCounter;
 import com.peoplein.moiming.repository.MemberMoimCounterRepository;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -11,6 +11,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.Query;
 import java.math.BigInteger;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import static com.peoplein.moiming.domain.QMemberMoimCounter.*;
@@ -61,5 +62,21 @@ public class MemberMoimCounterJpaRepository implements MemberMoimCounterReposito
     public void releaseLock(String lockName) {
         final Query query = em.createNativeQuery("SELECT RELEASE_LOCK(:lockName)");
         query.setParameter("lockName", lockName);
+    }
+
+    @Override
+    public List<MoimViewCountTuple> findByGroupByMoimId() {
+        // MoimId + Counter
+        return query.select(Projections.constructor(MoimViewCountTuple.class, memberMoimCounter.moimId, memberMoimCounter.count()))
+                .from(memberMoimCounter)
+                .groupBy(memberMoimCounter.moimId)
+                .fetch();
+    }
+
+    @Override
+    public void deleteByMoimIds(List<Long> moimIds) {
+        query.delete(memberMoimCounter)
+                .where(memberMoimCounter.moimId.in(moimIds))
+                .execute();
     }
 }

--- a/src/main/java/com/peoplein/moiming/repository/jpa/MemberMoimCounterJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/MemberMoimCounterJpaRepository.java
@@ -1,0 +1,65 @@
+package com.peoplein.moiming.repository.jpa;
+
+import com.peoplein.moiming.domain.MemberMoimCounter;
+import com.peoplein.moiming.domain.QMemberMoimCounter;
+import com.peoplein.moiming.repository.MemberMoimCounterRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static com.peoplein.moiming.domain.QMemberMoimCounter.*;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberMoimCounterJpaRepository implements MemberMoimCounterRepository {
+
+    private static final int LOCK_TIMEOUT = 1;
+
+    private final EntityManager em;
+    private final JPAQueryFactory query;
+
+    @Override
+    public void save(MemberMoimCounter memberMoimCounter) {
+        em.persist(memberMoimCounter);
+    }
+
+    @Override
+    public Optional<MemberMoimCounter> findBy(Long memberId, Long moimId, LocalDate date) {
+        MemberMoimCounter findInstance = query.select(memberMoimCounter)
+                .where(memberMoimCounter.memberId.eq(memberId),
+                        memberMoimCounter.moimId.eq(moimId),
+                        memberMoimCounter.visitDate.eq(date)).fetchOne();
+
+        return findInstance != null ?
+                Optional.of(findInstance) :
+                Optional.empty();
+    }
+
+    @Override
+    public boolean acquireLock(String lockName) {
+        final Query query = em.createNativeQuery("SELECT GET_LOCK(:lockName, :timeout)");
+        query.setParameter("lockName", lockName);
+        query.setParameter("timeout", LOCK_TIMEOUT);
+
+        for (int i = 0; i < 10; i++) {
+            BigInteger singleResult1 = (BigInteger) query.getSingleResult();
+            int acquire = singleResult1.signum();
+            if (acquire == 1) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void releaseLock(String lockName) {
+        final Query query = em.createNativeQuery("SELECT RELEASE_LOCK(:lockName)");
+        query.setParameter("lockName", lockName);
+    }
+}

--- a/src/main/java/com/peoplein/moiming/repository/jpa/MemberMoimMaterializedViewJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/MemberMoimMaterializedViewJpaRepository.java
@@ -1,0 +1,47 @@
+package com.peoplein.moiming.repository.jpa;
+
+import com.peoplein.moiming.domain.MemberMoimMaterializedView;
+import com.peoplein.moiming.repository.MemberMoimMaterializedViewRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static com.peoplein.moiming.domain.QMemberMoimMaterializedView.memberMoimMaterializedView;
+
+
+@Repository
+@RequiredArgsConstructor
+public class MemberMoimMaterializedViewJpaRepository implements MemberMoimMaterializedViewRepository {
+
+    private final EntityManager em;
+    private final JPAQueryFactory query;
+
+
+    @Override
+    public Long save(MemberMoimMaterializedView memberMoimMaterializedView) {
+        em.persist(memberMoimMaterializedView);
+        return memberMoimMaterializedView.getId();
+    }
+
+    @Override
+    public List<MemberMoimMaterializedView> findByMoimIds(List<Long> moimIds) {
+        return query.selectFrom(memberMoimMaterializedView)
+                .where(memberMoimMaterializedView.moimId.in(moimIds))
+                .fetch();
+    }
+
+    @Override
+    public List<MemberMoimMaterializedView> findAll() {
+        return query.selectFrom(memberMoimMaterializedView).fetch();
+    }
+
+    @Override
+    public void deleteMViews(List<Long> moimIds) {
+        query.delete(memberMoimMaterializedView)
+                .where(memberMoimMaterializedView.moimId.in(moimIds))
+                .execute();
+    }
+}

--- a/src/main/java/com/peoplein/moiming/service/MemberMoimCounterService.java
+++ b/src/main/java/com/peoplein/moiming/service/MemberMoimCounterService.java
@@ -1,14 +1,19 @@
 package com.peoplein.moiming.service;
 
 import com.peoplein.moiming.domain.MemberMoimCounter;
+import com.peoplein.moiming.domain.MemberMoimMaterializedView;
+import com.peoplein.moiming.domain.Moim;
 import com.peoplein.moiming.repository.MemberMoimCounterRepository;
+import com.peoplein.moiming.repository.MemberMoimMaterializedViewRepository;
+import com.peoplein.moiming.repository.MoimRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -18,6 +23,8 @@ public class MemberMoimCounterService {
 
     private static final int RETRY_COUNT = 3;
     private final MemberMoimCounterRepository memberMoimCounterRepository;
+    private final MemberMoimMaterializedViewRepository materializedViewRepository;
+    private final MoimRepository moimRepository;
 
     // 트랜잭션은 1개씩
     public void create(Long memberId, Long moimId, LocalDate visitDate) {
@@ -31,7 +38,7 @@ public class MemberMoimCounterService {
         }
 
         Optional<MemberMoimCounter> findInstance = memberMoimCounterRepository.findBy(memberId, moimId, visitDate);
-        if (!findInstance.isEmpty()) {
+        if (findInstance.isPresent()) {
             memberMoimCounterRepository.releaseLock(lockName);
             return;
         }
@@ -41,5 +48,43 @@ public class MemberMoimCounterService {
 
         // Named Lock release
         memberMoimCounterRepository.releaseLock(lockName);
+    }
+
+    public void update() {
+        final List<MemberMoimCounterRepository.MoimViewCountTuple> groupByResult = memberMoimCounterRepository.findByGroupByMoimId();
+        final Map<Long, MemberMoimMaterializedView> collected = groupByResult.stream()
+                .map(moimViewCountTuple -> MemberMoimMaterializedView.create(moimViewCountTuple.getViewCount(), moimViewCountTuple.getMoimId()))
+                .collect(Collectors.toMap(MemberMoimMaterializedView::getMoimId, memberMoimMaterializedView -> memberMoimMaterializedView));
+
+        final List<Long> moimIdList = new ArrayList<>(collected.keySet());
+        final List<MemberMoimMaterializedView> findMaterializedViewByMoimIds = materializedViewRepository.findByMoimIds(moimIdList);
+
+        findMaterializedViewByMoimIds.forEach(mView -> mView.updateCount(
+                collected.get(mView.getMoimId()).getCount()));
+
+        final Set<Long> inDBMoimIds = findMaterializedViewByMoimIds.stream()
+                .map(MemberMoimMaterializedView::getMoimId)
+                .collect(Collectors.toSet());
+
+        final Set<Long> findMViewMoimIds = collected.keySet();
+        findMViewMoimIds.removeAll(inDBMoimIds);
+
+        findMViewMoimIds.stream()
+                .map(collected::get)
+                .forEach(materializedViewRepository::save);
+    }
+
+    public void deleteDoesNotExistMoim() {
+
+        final List<MemberMoimMaterializedView> mViews = materializedViewRepository.findAll();
+        final Set<Long> mViewMoimIds = mViews.stream().map(MemberMoimMaterializedView::getMoimId).collect(Collectors.toSet());
+
+        final Set<Long> findMoimIds = moimRepository.findAllMoim().stream().map(Moim::getId).collect(Collectors.toSet());
+
+        mViewMoimIds.removeAll(findMoimIds);
+
+        final List<Long> shouldRemoveMoimIds = new ArrayList<>(mViewMoimIds);
+        materializedViewRepository.deleteMViews(shouldRemoveMoimIds);
+        memberMoimCounterRepository.deleteByMoimIds(shouldRemoveMoimIds);
     }
 }

--- a/src/main/java/com/peoplein/moiming/service/MemberMoimCounterService.java
+++ b/src/main/java/com/peoplein/moiming/service/MemberMoimCounterService.java
@@ -1,0 +1,45 @@
+package com.peoplein.moiming.service;
+
+import com.peoplein.moiming.domain.MemberMoimCounter;
+import com.peoplein.moiming.repository.MemberMoimCounterRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberMoimCounterService {
+
+    private static final int RETRY_COUNT = 3;
+    private final MemberMoimCounterRepository memberMoimCounterRepository;
+
+    // 트랜잭션은 1개씩
+    public void create(Long memberId, Long moimId, LocalDate visitDate) {
+        // Named Lock get
+        final String lockName = String.format("%d-%d", memberId, moimId);
+
+        for (int i = 0; i < RETRY_COUNT; i++) {
+            boolean lock = memberMoimCounterRepository.acquireLock(lockName);
+            if (lock)
+                break;
+        }
+
+        Optional<MemberMoimCounter> findInstance = memberMoimCounterRepository.findBy(memberId, moimId, visitDate);
+        if (!findInstance.isEmpty()) {
+            memberMoimCounterRepository.releaseLock(lockName);
+            return;
+        }
+
+        MemberMoimCounter createdInstance = MemberMoimCounter.create(memberId, moimId, visitDate);
+        memberMoimCounterRepository.save(createdInstance);
+
+        // Named Lock release
+        memberMoimCounterRepository.releaseLock(lockName);
+    }
+}

--- a/src/test/java/com/peoplein/moiming/service/MemberMoimCounterServiceTest.java
+++ b/src/test/java/com/peoplein/moiming/service/MemberMoimCounterServiceTest.java
@@ -1,0 +1,154 @@
+package com.peoplein.moiming.service;
+
+import com.peoplein.moiming.domain.MemberMoimCounter;
+import com.peoplein.moiming.domain.MemberMoimMaterializedView;
+import com.peoplein.moiming.repository.MemberMoimMaterializedViewRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+@SpringBootTest
+@Transactional
+class MemberMoimCounterServiceTest {
+
+    @Autowired
+    EntityManager em;
+
+    @Autowired
+    MemberMoimCounterService memberMoimCounterService;
+
+    @Autowired
+    MemberMoimMaterializedViewRepository materializedViewRepository;
+
+    @Test
+    void test1() {
+        // Given
+        final int size = 100;
+        List<MemberMoimCounter> memberMoimCounters = IntStream.range(1, 1 + size)
+                .mapToObj(value -> MemberMoimCounter.create(value + 100L, value + 1000L, LocalDate.now()))
+                .collect(Collectors.toList());
+
+        memberMoimCounters.forEach(memberMoimCounter -> em.persist(memberMoimCounter));
+
+        // When
+        memberMoimCounterService.update();
+
+        // Then
+        List<MemberMoimMaterializedView> result = em.createQuery("SELECT m FROM MemberMoimMaterializedView m", MemberMoimMaterializedView.class)
+                .getResultList();
+
+        assertThat(result.size()).isEqualTo(size);
+    }
+
+    @Test
+    void test2() {
+        // Given
+        LocalDate date1 = LocalDate.of(2023, 9, 9);
+        LocalDate date2 = LocalDate.of(2023, 9, 9);
+        LocalDate date3 = LocalDate.of(2023, 9, 9);
+        LocalDate date4 = LocalDate.of(2023, 9, 9);
+        LocalDate date5 = LocalDate.of(2023, 9, 9);
+
+        MemberMoimCounter m1 = MemberMoimCounter.create(1L, 1000L, date1);
+        MemberMoimCounter m2 = MemberMoimCounter.create(1L, 1000L, date2);
+        MemberMoimCounter m3 = MemberMoimCounter.create(1L, 1002L, date3);
+        MemberMoimCounter m4 = MemberMoimCounter.create(1L, 1001L, date4);
+        MemberMoimCounter m5 = MemberMoimCounter.create(1L, 1000L, date5);
+        MemberMoimCounter m6 = MemberMoimCounter.create(2L, 1000L, date1);
+
+        em.persist(m1);
+        em.persist(m2);
+        em.persist(m3);
+        em.persist(m4);
+        em.persist(m5);
+        em.persist(m6);
+
+        // When
+        memberMoimCounterService.update();
+
+        // Then
+        List<MemberMoimMaterializedView> result = em.createQuery("SELECT m FROM MemberMoimMaterializedView m", MemberMoimMaterializedView.class)
+                .getResultList();
+        List<Long> resultList = result.stream().map(memberMoimMaterializedView -> memberMoimMaterializedView.getCount()).collect(Collectors.toList());
+
+        assertThat(result.size()).isEqualTo(3);
+        assertThat(resultList).containsExactly(4L, 1L, 1L);
+    }
+
+    @Test
+    void test3() {
+        // Given
+        LocalDate date1 = LocalDate.of(2023, 9, 9);
+        LocalDate date2 = LocalDate.of(2023, 9, 9);
+        LocalDate date3 = LocalDate.of(2023, 9, 9);
+        LocalDate date4 = LocalDate.of(2023, 9, 9);
+        LocalDate date5 = LocalDate.of(2023, 9, 9);
+
+        MemberMoimCounter m1 = MemberMoimCounter.create(1L, 1000L, date1);
+        MemberMoimCounter m2 = MemberMoimCounter.create(1L, 1000L, date2);
+        MemberMoimCounter m3 = MemberMoimCounter.create(1L, 1002L, date3);
+        MemberMoimCounter m4 = MemberMoimCounter.create(1L, 1001L, date4);
+        MemberMoimCounter m5 = MemberMoimCounter.create(1L, 1000L, date5);
+        MemberMoimCounter m6 = MemberMoimCounter.create(2L, 1000L, date1);
+
+        em.persist(m1);
+        em.persist(m2);
+        em.persist(m3);
+        em.persist(m4);
+        em.persist(m5);
+        em.persist(m6);
+        memberMoimCounterService.update();
+
+        em.persist(MemberMoimCounter.create(10L, 1000L, LocalDate.of(2023,10,9)));
+        em.persist(MemberMoimCounter.create(11L, 1000L, LocalDate.of(2023,10,9)));
+        em.persist(MemberMoimCounter.create(12L, 1000L, LocalDate.of(2023,10,9)));
+        em.persist(MemberMoimCounter.create(10L, 1001L, LocalDate.of(2023,10,9)));
+        em.persist(MemberMoimCounter.create(11L, 1001L, LocalDate.of(2023,10,9)));
+        em.persist(MemberMoimCounter.create(12L, 1001L, LocalDate.of(2023,10,9)));
+
+        // When
+        memberMoimCounterService.update();
+
+        // Then
+        List<MemberMoimMaterializedView> result = em.createQuery("SELECT m FROM MemberMoimMaterializedView m", MemberMoimMaterializedView.class)
+                .getResultList();
+        List<Long> resultList = result.stream().map(memberMoimMaterializedView -> memberMoimMaterializedView.getCount()).collect(Collectors.toList());
+
+        assertThat(result.size()).isEqualTo(3);
+        assertThat(resultList).containsExactly(7L, 4L, 1L);
+    }
+
+    @Test
+    void test4() {
+        // Given
+        final int size = 100;
+        List<MemberMoimCounter> memberMoimCounters = IntStream.range(1, 1 + size)
+                .mapToObj(value -> MemberMoimCounter.create(value + 100L, value + 1000L, LocalDate.now()))
+                .collect(Collectors.toList());
+
+        memberMoimCounters.forEach(memberMoimCounter -> em.persist(memberMoimCounter));
+        memberMoimCounterService.update();
+
+        List<MemberMoimMaterializedView> before = em.createQuery("SELECT m FROM MemberMoimMaterializedView m", MemberMoimMaterializedView.class).getResultList();
+        assertThat(before).isNotEmpty();
+
+        // When
+        memberMoimCounterService.deleteDoesNotExistMoim();
+
+        // Then
+        List<MemberMoimMaterializedView> mView = em.createQuery("SELECT m FROM MemberMoimMaterializedView m", MemberMoimMaterializedView.class).getResultList();
+        List<MemberMoimCounter> counterList = em.createQuery("SELECT m FROM MemberMoimCounter m", MemberMoimCounter.class).getResultList();
+
+        assertThat(mView.size()).isEqualTo(0);
+        assertThat(counterList.size()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
### 모임별 조회수 구현
- `Redis`는 사용하지 않도록 했습니다. (서버 비용 + 유지보수 비용 고려)
- 동시성은 `MySQL`에서 `Lock` 이용해 `Atomic` 하게 처리하도록 구현했습니다. 
- 요청 → 조회수 업데이트 객체(`MemberMoimCounter`) 생성 및 `Persist` → `Cron`에서 `MoimMaterializedView Update`. 
- `Moim` 삭제 되었을 때, `MoimMaterializedView`도 동기화 되도록 구현해두었습니다.  (`Cron`에서 `MoimMaterializedView delete`.)

### 우려부분
- MemberMoimCounter 이력이 많이 쌓이면, DB + 쿼리가 느려질 수 있음. 이 때는 Redis로 이전 고려.