### PR TITLE
모임별 Unique Count 구현

### DIFF
--- a/src/main/java/com/peoplein/moiming/MoimingApplication.java
+++ b/src/main/java/com/peoplein/moiming/MoimingApplication.java
@@ -2,11 +2,13 @@ package com.peoplein.moiming;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 
 @SpringBootApplication
 @EnableScheduling
+@EnableAsync
 public class MoimingApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/peoplein/moiming/config/AsyncConfiguration.java
+++ b/src/main/java/com/peoplein/moiming/config/AsyncConfiguration.java
@@ -1,0 +1,23 @@
+package com.peoplein.moiming.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class AsyncConfiguration {
+
+    @Bean
+    public TaskExecutor taskExecutor() {
+        final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(10);
+        executor.setMaxPoolSize(20);
+        executor.setPrestartAllCoreThreads(true);
+        executor.setQueueCapacity(1000);
+        return executor;
+    }
+
+
+
+}

--- a/src/main/java/com/peoplein/moiming/controller/MoimController.java
+++ b/src/main/java/com/peoplein/moiming/controller/MoimController.java
@@ -3,18 +3,22 @@ package com.peoplein.moiming.controller;
 
 import com.peoplein.moiming.NetworkSetting;
 import com.peoplein.moiming.domain.Member;
+import com.peoplein.moiming.event.MemberMoimCounterEvent;
 import com.peoplein.moiming.model.ResponseBodyDto;
 import com.peoplein.moiming.model.dto.request_b.MoimRequestDto;
 import com.peoplein.moiming.model.dto.response_b.MoimResponseDto;
+import com.peoplein.moiming.service.MemberMoimCounterService;
 import com.peoplein.moiming.service.MoimService;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -23,6 +27,7 @@ import java.util.List;
 public class MoimController {
 
     private final MoimService moimService;
+    private final ApplicationEventPublisher publisher;
 
     /*
      모임 생성 요청 수신
@@ -58,6 +63,10 @@ public class MoimController {
     @GetMapping("/{moimId}")
     public ResponseEntity<?> getMoim(@PathVariable(name = "moimId") Long moimId) {
         Member curMember = (Member) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        final MemberMoimCounterEvent event = MemberMoimCounterEvent.create(curMember.getId(), moimId, LocalDate.now());
+        publisher.publishEvent(event);
+
         MoimResponseDto responseDto = moimService.getMoim(moimId, curMember);
         return ResponseEntity.ok().body(ResponseBodyDto.createResponse(1, "모임 일반 조회 완료", responseDto));
     }

--- a/src/main/java/com/peoplein/moiming/cron/MoimCounterUpdateScheduler.java
+++ b/src/main/java/com/peoplein/moiming/cron/MoimCounterUpdateScheduler.java
@@ -1,0 +1,38 @@
+package com.peoplein.moiming.cron;
+
+import com.peoplein.moiming.domain.FileUpload;
+import com.peoplein.moiming.repository.FileUploadRepository;
+import com.peoplein.moiming.service.MemberMoimCounterService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MoimCounterUpdateScheduler {
+    private final MemberMoimCounterService memberMoimCounterService;
+
+//    @Scheduled(cron = "0 */10 * * * *")
+    @Scheduled(cron = "*/1 * * * * *")
+    public void update() {
+        log.info("MoimCounterUpdateScheduler started update.");
+        memberMoimCounterService.update();
+    }
+
+//    @Scheduled(cron = "0 * */12 * * *")
+    @Scheduled(cron = "*/1 * * * * *")
+    public void delete() {
+        log.info("MoimCounterUpdateScheduler started deleted.");
+        memberMoimCounterService.deleteDoesNotExistMoim();
+    }
+}

--- a/src/main/java/com/peoplein/moiming/domain/MemberMoimCounter.java
+++ b/src/main/java/com/peoplein/moiming/domain/MemberMoimCounter.java
@@ -1,0 +1,42 @@
+package com.peoplein.moiming.domain;
+
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberMoimCounter {
+
+    @Id
+    @Column(name = "member_moim_counter_id")
+    @GeneratedValue
+    private Long id;
+
+    private Long memberId;
+
+    private Long moimId;
+
+    private LocalDate visitDate;
+
+    private MemberMoimCounter(Long memberId, Long moimId, LocalDate visitDate) {
+        this.memberId = memberId;
+        this.moimId = moimId;
+        this.visitDate = visitDate;
+    }
+
+    public static MemberMoimCounter create(long memberId, long moimId, LocalDate visitDate) {
+        if (visitDate == null)
+            throw new IllegalArgumentException(String.format("wrong input. MemberId = {}, MoimId = {}, visitDate = {}",
+                    memberId, moimId, visitDate));
+        return new MemberMoimCounter(memberId, moimId, visitDate);
+    }
+
+}

--- a/src/main/java/com/peoplein/moiming/domain/MemberMoimMaterializedView.java
+++ b/src/main/java/com/peoplein/moiming/domain/MemberMoimMaterializedView.java
@@ -1,0 +1,40 @@
+package com.peoplein.moiming.domain;
+
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberMoimMaterializedView {
+
+
+    @Id
+    @Column(name = "member_moim_materialized_view_id")
+    @GeneratedValue
+    private Long id;
+
+    private Long count;
+    private Long moimId; // Moim 객체를 같이 줘야할 듯? 다 필요는 없을 것 같고. 여기서 in 몇개만 찾아내서 주면 될 듯. ㅇㅇ..
+
+    private MemberMoimMaterializedView(Long count, Long moimId) {
+        this.count = count;
+        this.moimId = moimId;
+    }
+
+    public void updateCount(Long count) {
+        this.count = count;
+    }
+
+
+    public static MemberMoimMaterializedView create(Long count, Long moimId) {
+        return new MemberMoimMaterializedView(count, moimId);
+    }
+}

--- a/src/main/java/com/peoplein/moiming/event/MemberMoimCounterEvent.java
+++ b/src/main/java/com/peoplein/moiming/event/MemberMoimCounterEvent.java
@@ -1,0 +1,23 @@
+package com.peoplein.moiming.event;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class MemberMoimCounterEvent {
+
+    private final Long memberId;
+    private final Long moimId;
+    private final LocalDate visitDated;
+
+    private MemberMoimCounterEvent(Long memberId, Long moimId, LocalDate visitDated) {
+        this.memberId = memberId;
+        this.moimId = moimId;
+        this.visitDated = visitDated;
+    }
+
+    public static MemberMoimCounterEvent create(Long memberId, Long moimId, LocalDate visitDated) {
+        return new MemberMoimCounterEvent(memberId, moimId, visitDated);
+    }
+}

--- a/src/main/java/com/peoplein/moiming/event/MemberMoimCounterEventListener.java
+++ b/src/main/java/com/peoplein/moiming/event/MemberMoimCounterEventListener.java
@@ -1,0 +1,27 @@
+package com.peoplein.moiming.event;
+
+import com.peoplein.moiming.service.MemberMoimCounterService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Async
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MemberMoimCounterEventListener {
+
+    private final MemberMoimCounterService memberMoimCounterService;
+
+    @EventListener
+    public void handleEvent(MemberMoimCounterEvent event) {
+        log.info("event execute = {}", event);
+        memberMoimCounterService.create(event.getMemberId(), event.getMoimId(), LocalDate.now());
+    }
+
+
+}

--- a/src/main/java/com/peoplein/moiming/repository/MemberMoimCounterRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/MemberMoimCounterRepository.java
@@ -1,0 +1,29 @@
+package com.peoplein.moiming.repository;
+
+import com.peoplein.moiming.domain.MemberMoimCounter;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface MemberMoimCounterRepository {
+
+    void save(MemberMoimCounter memberMoimCounter);
+    Optional<MemberMoimCounter> findBy(Long memberId, Long moimId, LocalDate date);
+    boolean acquireLock(String lockName);
+    void releaseLock(String lockName);
+    List<MoimViewCountTuple> findByGroupByMoimId();
+    void deleteByMoimIds(List<Long> moimIds);
+
+    @Getter
+    class MoimViewCountTuple {
+        private final Long moimId;
+        private final Long viewCount;
+
+        public MoimViewCountTuple(Long moimId, Long viewCount) {
+            this.moimId = moimId;
+            this.viewCount = viewCount;
+        }
+    }
+}

--- a/src/main/java/com/peoplein/moiming/repository/MemberMoimMaterializedViewRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/MemberMoimMaterializedViewRepository.java
@@ -1,0 +1,13 @@
+package com.peoplein.moiming.repository;
+
+import com.peoplein.moiming.domain.MemberMoimMaterializedView;
+
+import java.util.List;
+
+public interface MemberMoimMaterializedViewRepository {
+
+    Long save(MemberMoimMaterializedView memberMoimMaterializedView);
+    List<MemberMoimMaterializedView> findByMoimIds(List<Long> moimIds);
+    List<MemberMoimMaterializedView> findAll();
+    void deleteMViews(List<Long> moimIds);
+}

--- a/src/main/java/com/peoplein/moiming/repository/jpa/MemberMoimCounterJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/MemberMoimCounterJpaRepository.java
@@ -1,0 +1,84 @@
+package com.peoplein.moiming.repository.jpa;
+
+import com.peoplein.moiming.domain.MemberMoimCounter;
+import com.peoplein.moiming.repository.MemberMoimCounterRepository;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static com.peoplein.moiming.domain.QMemberMoimCounter.*;
+
+
+@Repository
+@RequiredArgsConstructor
+public class MemberMoimCounterJpaRepository implements MemberMoimCounterRepository {
+
+    private static final int LOCK_TIMEOUT = 1;
+
+    private final EntityManager em;
+    private final JPAQueryFactory query;
+
+    @Override
+    public void save(MemberMoimCounter memberMoimCounter) {
+        em.persist(memberMoimCounter);
+    }
+
+    @Override
+    public Optional<MemberMoimCounter> findBy(Long memberId, Long moimId, LocalDate date) {
+        MemberMoimCounter findInstance = query.select(memberMoimCounter)
+                .where(memberMoimCounter.memberId.eq(memberId),
+                        memberMoimCounter.moimId.eq(moimId),
+                        memberMoimCounter.visitDate.eq(date)).fetchOne();
+
+        return findInstance != null ?
+                Optional.of(findInstance) :
+                Optional.empty();
+    }
+
+    @Override
+    public boolean acquireLock(String lockName) {
+        final Query query = em.createNativeQuery("SELECT GET_LOCK(:lockName, :timeout)");
+        query.setParameter("lockName", lockName);
+        query.setParameter("timeout", LOCK_TIMEOUT);
+
+        for (int i = 0; i < 10; i++) {
+            BigInteger singleResult1 = (BigInteger) query.getSingleResult();
+            int acquire = singleResult1.signum();
+            if (acquire == 1) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void releaseLock(String lockName) {
+        final Query query = em.createNativeQuery("SELECT RELEASE_LOCK(:lockName)");
+        query.setParameter("lockName", lockName);
+        query.executeUpdate();
+    }
+
+    @Override
+    public List<MoimViewCountTuple> findByGroupByMoimId() {
+        // MoimId + Counter
+        return query.select(Projections.constructor(MoimViewCountTuple.class, memberMoimCounter.moimId, memberMoimCounter.count()))
+                .from(memberMoimCounter)
+                .groupBy(memberMoimCounter.moimId)
+                .fetch();
+    }
+
+    @Override
+    public void deleteByMoimIds(List<Long> moimIds) {
+        query.delete(memberMoimCounter)
+                .where(memberMoimCounter.moimId.in(moimIds))
+                .execute();
+    }
+}

--- a/src/main/java/com/peoplein/moiming/repository/jpa/MemberMoimMaterializedViewJpaRepository.java
+++ b/src/main/java/com/peoplein/moiming/repository/jpa/MemberMoimMaterializedViewJpaRepository.java
@@ -1,0 +1,46 @@
+package com.peoplein.moiming.repository.jpa;
+
+import com.peoplein.moiming.domain.MemberMoimMaterializedView;
+import com.peoplein.moiming.repository.MemberMoimMaterializedViewRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static com.peoplein.moiming.domain.QMemberMoimMaterializedView.memberMoimMaterializedView;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberMoimMaterializedViewJpaRepository implements MemberMoimMaterializedViewRepository {
+
+    private final EntityManager em;
+    private final JPAQueryFactory query;
+
+
+    @Override
+    public Long save(MemberMoimMaterializedView memberMoimMaterializedView) {
+        em.persist(memberMoimMaterializedView);
+        return memberMoimMaterializedView.getId();
+    }
+
+    @Override
+    public List<MemberMoimMaterializedView> findByMoimIds(List<Long> moimIds) {
+        return query.selectFrom(memberMoimMaterializedView)
+                .where(memberMoimMaterializedView.moimId.in(moimIds))
+                .fetch();
+    }
+
+    @Override
+    public List<MemberMoimMaterializedView> findAll() {
+        return query.selectFrom(memberMoimMaterializedView).fetch();
+    }
+
+    @Override
+    public void deleteMViews(List<Long> moimIds) {
+        query.delete(memberMoimMaterializedView)
+                .where(memberMoimMaterializedView.moimId.in(moimIds))
+                .execute();
+    }
+}

--- a/src/main/java/com/peoplein/moiming/service/MemberMoimCounterService.java
+++ b/src/main/java/com/peoplein/moiming/service/MemberMoimCounterService.java
@@ -1,0 +1,90 @@
+package com.peoplein.moiming.service;
+
+import com.peoplein.moiming.domain.MemberMoimCounter;
+import com.peoplein.moiming.domain.MemberMoimMaterializedView;
+import com.peoplein.moiming.domain.Moim;
+import com.peoplein.moiming.repository.MemberMoimCounterRepository;
+import com.peoplein.moiming.repository.MemberMoimMaterializedViewRepository;
+import com.peoplein.moiming.repository.MoimRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberMoimCounterService {
+
+    private static final int RETRY_COUNT = 3;
+    private final MemberMoimCounterRepository memberMoimCounterRepository;
+    private final MemberMoimMaterializedViewRepository materializedViewRepository;
+    private final MoimRepository moimRepository;
+
+    // 트랜잭션은 1개씩
+    public void create(Long memberId, Long moimId, LocalDate visitDate) {
+        // Named Lock get
+        final String lockName = String.format("%d-%d", memberId, moimId);
+
+        for (int i = 0; i < RETRY_COUNT; i++) {
+            boolean lock = memberMoimCounterRepository.acquireLock(lockName);
+            if (lock)
+                break;
+        }
+
+        Optional<MemberMoimCounter> findInstance = memberMoimCounterRepository.findBy(memberId, moimId, visitDate);
+        if (findInstance.isPresent()) {
+            memberMoimCounterRepository.releaseLock(lockName);
+            return;
+        }
+
+        MemberMoimCounter createdInstance = MemberMoimCounter.create(memberId, moimId, visitDate);
+        memberMoimCounterRepository.save(createdInstance);
+
+        // Named Lock release
+        memberMoimCounterRepository.releaseLock(lockName);
+    }
+
+    public void update() {
+        final List<MemberMoimCounterRepository.MoimViewCountTuple> groupByResult = memberMoimCounterRepository.findByGroupByMoimId();
+        final Map<Long, MemberMoimMaterializedView> collected = groupByResult.stream()
+                .map(moimViewCountTuple -> MemberMoimMaterializedView.create(moimViewCountTuple.getViewCount(), moimViewCountTuple.getMoimId()))
+                .collect(Collectors.toMap(MemberMoimMaterializedView::getMoimId, memberMoimMaterializedView -> memberMoimMaterializedView));
+
+        final List<Long> moimIdList = new ArrayList<>(collected.keySet());
+        final List<MemberMoimMaterializedView> findMaterializedViewByMoimIds = materializedViewRepository.findByMoimIds(moimIdList);
+
+        findMaterializedViewByMoimIds.forEach(mView -> mView.updateCount(
+                collected.get(mView.getMoimId()).getCount()));
+
+        final Set<Long> inDBMoimIds = findMaterializedViewByMoimIds.stream()
+                .map(MemberMoimMaterializedView::getMoimId)
+                .collect(Collectors.toSet());
+
+        final Set<Long> findMViewMoimIds = collected.keySet();
+        findMViewMoimIds.removeAll(inDBMoimIds);
+
+        findMViewMoimIds.stream()
+                .map(collected::get)
+                .forEach(materializedViewRepository::save);
+    }
+
+    public void deleteDoesNotExistMoim() {
+
+        final List<MemberMoimMaterializedView> mViews = materializedViewRepository.findAll();
+        final Set<Long> mViewMoimIds = mViews.stream().map(MemberMoimMaterializedView::getMoimId).collect(Collectors.toSet());
+
+        final Set<Long> findMoimIds = moimRepository.findAllMoim().stream().map(Moim::getId).collect(Collectors.toSet());
+
+        mViewMoimIds.removeAll(findMoimIds);
+
+        final List<Long> shouldRemoveMoimIds = new ArrayList<>(mViewMoimIds);
+        materializedViewRepository.deleteMViews(shouldRemoveMoimIds);
+        memberMoimCounterRepository.deleteByMoimIds(shouldRemoveMoimIds);
+    }
+}

--- a/src/test/java/com/peoplein/moiming/service/MemberMoimCounterServiceTest.java
+++ b/src/test/java/com/peoplein/moiming/service/MemberMoimCounterServiceTest.java
@@ -1,0 +1,157 @@
+package com.peoplein.moiming.service;
+
+import com.peoplein.moiming.domain.MemberMoimCounter;
+import com.peoplein.moiming.domain.MemberMoimMaterializedView;
+import com.peoplein.moiming.repository.MemberMoimMaterializedViewRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class MemberMoimCounterServiceTest  {
+
+    @Autowired
+    EntityManager em;
+
+    @Autowired
+    MemberMoimCounterService memberMoimCounterService;
+
+    @Autowired
+    MemberMoimMaterializedViewRepository materializedViewRepository;
+
+    @Test
+    void test1() {
+        // Given
+        final int size = 100;
+        List<MemberMoimCounter> memberMoimCounters = IntStream.range(1, 1 + size)
+                .mapToObj(value -> MemberMoimCounter.create(value + 100L, value + 1000L, LocalDate.now()))
+                .collect(Collectors.toList());
+
+        memberMoimCounters.forEach(memberMoimCounter -> em.persist(memberMoimCounter));
+
+        // When
+        memberMoimCounterService.update();
+
+        // Then
+        List<MemberMoimMaterializedView> result = em.createQuery("SELECT m FROM MemberMoimMaterializedView m", MemberMoimMaterializedView.class)
+                .getResultList();
+
+        assertThat(result.size()).isEqualTo(size);
+    }
+
+    @Test
+    void test2() {
+        // Given
+        LocalDate date1 = LocalDate.of(2023, 9, 9);
+        LocalDate date2 = LocalDate.of(2023, 9, 9);
+        LocalDate date3 = LocalDate.of(2023, 9, 9);
+        LocalDate date4 = LocalDate.of(2023, 9, 9);
+        LocalDate date5 = LocalDate.of(2023, 9, 9);
+
+        MemberMoimCounter m1 = MemberMoimCounter.create(1L, 1000L, date1);
+        MemberMoimCounter m2 = MemberMoimCounter.create(1L, 1000L, date2);
+        MemberMoimCounter m3 = MemberMoimCounter.create(1L, 1002L, date3);
+        MemberMoimCounter m4 = MemberMoimCounter.create(1L, 1001L, date4);
+        MemberMoimCounter m5 = MemberMoimCounter.create(1L, 1000L, date5);
+        MemberMoimCounter m6 = MemberMoimCounter.create(2L, 1000L, date1);
+
+        em.persist(m1);
+        em.persist(m2);
+        em.persist(m3);
+        em.persist(m4);
+        em.persist(m5);
+        em.persist(m6);
+
+        // When
+        memberMoimCounterService.update();
+
+        // Then
+        List<MemberMoimMaterializedView> result = em.createQuery("SELECT m FROM MemberMoimMaterializedView m", MemberMoimMaterializedView.class)
+                .getResultList();
+        List<Long> resultList = result.stream().map(memberMoimMaterializedView -> memberMoimMaterializedView.getCount()).collect(Collectors.toList());
+
+        assertThat(result.size()).isEqualTo(3);
+        assertThat(resultList).containsExactly(4L, 1L, 1L);
+    }
+
+    @Test
+    void test3() {
+        // Given
+        LocalDate date1 = LocalDate.of(2023, 9, 9);
+        LocalDate date2 = LocalDate.of(2023, 9, 9);
+        LocalDate date3 = LocalDate.of(2023, 9, 9);
+        LocalDate date4 = LocalDate.of(2023, 9, 9);
+        LocalDate date5 = LocalDate.of(2023, 9, 9);
+
+        MemberMoimCounter m1 = MemberMoimCounter.create(1L, 1000L, date1);
+        MemberMoimCounter m2 = MemberMoimCounter.create(1L, 1000L, date2);
+        MemberMoimCounter m3 = MemberMoimCounter.create(1L, 1002L, date3);
+        MemberMoimCounter m4 = MemberMoimCounter.create(1L, 1001L, date4);
+        MemberMoimCounter m5 = MemberMoimCounter.create(1L, 1000L, date5);
+        MemberMoimCounter m6 = MemberMoimCounter.create(2L, 1000L, date1);
+
+        em.persist(m1);
+        em.persist(m2);
+        em.persist(m3);
+        em.persist(m4);
+        em.persist(m5);
+        em.persist(m6);
+        memberMoimCounterService.update();
+
+        em.persist(MemberMoimCounter.create(10L, 1000L, LocalDate.of(2023,10,9)));
+        em.persist(MemberMoimCounter.create(11L, 1000L, LocalDate.of(2023,10,9)));
+        em.persist(MemberMoimCounter.create(12L, 1000L, LocalDate.of(2023,10,9)));
+        em.persist(MemberMoimCounter.create(10L, 1001L, LocalDate.of(2023,10,9)));
+        em.persist(MemberMoimCounter.create(11L, 1001L, LocalDate.of(2023,10,9)));
+        em.persist(MemberMoimCounter.create(12L, 1001L, LocalDate.of(2023,10,9)));
+
+        // When
+        memberMoimCounterService.update();
+
+        // Then
+        List<MemberMoimMaterializedView> result = em.createQuery("SELECT m FROM MemberMoimMaterializedView m", MemberMoimMaterializedView.class)
+                .getResultList();
+        List<Long> resultList = result.stream().map(memberMoimMaterializedView -> memberMoimMaterializedView.getCount()).collect(Collectors.toList());
+
+        assertThat(result.size()).isEqualTo(3);
+        assertThat(resultList).containsExactly(7L, 4L, 1L);
+    }
+
+    @Test
+    void test4() {
+        // Given
+        final int size = 100;
+        List<MemberMoimCounter> memberMoimCounters = IntStream.range(1, 1 + size)
+                .mapToObj(value -> MemberMoimCounter.create(value + 100L, value + 1000L, LocalDate.now()))
+                .collect(Collectors.toList());
+
+        memberMoimCounters.forEach(memberMoimCounter -> em.persist(memberMoimCounter));
+        memberMoimCounterService.update();
+
+        List<MemberMoimMaterializedView> before = em.createQuery("SELECT m FROM MemberMoimMaterializedView m", MemberMoimMaterializedView.class).getResultList();
+        assertThat(before).isNotEmpty();
+
+        // When
+        memberMoimCounterService.deleteDoesNotExistMoim();
+
+        // Then
+        List<MemberMoimMaterializedView> mView = em.createQuery("SELECT m FROM MemberMoimMaterializedView m", MemberMoimMaterializedView.class).getResultList();
+        List<MemberMoimCounter> counterList = em.createQuery("SELECT m FROM MemberMoimCounter m", MemberMoimCounter.class).getResultList();
+
+        assertThat(mView.size()).isEqualTo(0);
+        assertThat(counterList.size()).isEqualTo(0);
+    }
+}


### PR DESCRIPTION
### 모임별 조회수 구현
- `Redis`는 사용하지 않도록 했습니다. (서버 비용 + 유지보수 비용 고려)
- 동시성은 `MySQL`에서 `Lock` 이용해 `Atomic` 하게 처리하도록 구현했습니다. 
- 요청 → 조회수 업데이트 객체(`MemberMoimCounter`) 생성 및 `Persist` → `Cron`에서 `MoimMaterializedView Update`. 
- `Moim` 삭제 되었을 때, `MoimMaterializedView`도 동기화 되도록 구현해두었습니다.  (`Cron`에서 `MoimMaterializedView delete`.)

### 우려부분
- MemberMoimCounter 이력이 많이 쌓이면, DB + 쿼리가 느려질 수 있음. 이 때는 Redis로 이전 고려.


### Q & A
- 이벤트 발생은 어떻게 되는건가요..? 
  - `publisher.publishEvent(event);` 메서드가 호출될 때 생성됩니다 😃  
- 트랜젝셔널 어노테이션이 트랜젝션을 보장해주기 때문에 autocommit 와 locking 을 관리해주는 거라고 생각했는데, 직접 Lock 을 관리하시는 이유가 있을까요? 위 Repository 의 acquire Lock 을 이해 못해서 이해가 안되는 것 같기도 하네요.
  - `@Transactional`이 필요한 lock을 처리해주기는 하지만, 그 lock은 MySQL의 Transaction Isolation Level 수준에 기인합니다. 이 락을 처리하는 경우는 MySQL의 Default Transaction Isolation Level로 처리할 수 없는 동시성 문제를 대응하기 위함입니다. 
  - 문제 되는 경우:  `UserA`가 `MoimB`를 조회하자마자 응답을 기다리지 않고 새로고침을 여러 번 하는 경우, 서버 입장에서는 아직까지 `UserA`가 `MoimB`를 한번도 조회한 적이 없다고 판단할 것입니다. 이 때, 동시에 `UserA`가 `MoimB`를 방문했다는 `MemberMoimCounter` 객체가 생성되어서 DB로 Insert 된다면, 하루에 한 사람이 한 모임의 조회수를 1만 올릴 수 있다는 요구조건을 만족할 수 없습니다. 